### PR TITLE
307 add hurricanes to risk ensemble

### DIFF
--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -589,7 +589,12 @@ class Hazard:
             "static", "templates", self.site.attrs.sfincs.offshore_model
         )
         if self.event_mode == Mode.risk:
-            event_dir = self.database_input_path / "events" / self.event_set.attrs.name / self.event.attrs.name
+            event_dir = (
+                self.database_input_path
+                / "events"
+                / self.event_set.attrs.name
+                / self.event.attrs.name
+            )
         else:
             event_dir = self.database_input_path / "events" / self.event.attrs.name
 
@@ -625,13 +630,11 @@ class Hazard:
             spw_name = "hurricane.spw"
             offshore_model.set_config_spw(spw_name=spw_name)
             if event_dir.joinpath(spw_name).is_file():
-                logging.info(
-                    "Using existing hurricane meteo data."
-                )
+                logging.info("Using existing hurricane meteo data.")
                 # copy spw file from event directory to offshore model folder
                 shutil.copy2(
-                        event_dir.joinpath(spw_name), 
-                        self.simulation_paths_offshore[ii].joinpath(spw_name),
+                    event_dir.joinpath(spw_name),
+                    self.simulation_paths_offshore[ii].joinpath(spw_name),
                 )
             else:
                 logging.info(
@@ -644,8 +647,8 @@ class Hazard:
                 )
                 # save created spw file in the event directory
                 shutil.copy2(
-                        self.simulation_paths_offshore[ii].joinpath(spw_name),
-                        event_dir.joinpath(spw_name), 
+                    self.simulation_paths_offshore[ii].joinpath(spw_name),
+                    event_dir.joinpath(spw_name),
                 )
                 logging.info("Finished generating meteo data from hurricane track.")
 

--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -309,18 +309,18 @@ class Hazard:
         # Indicator that hazard has run
         self.__setattr__("has_run", True)
 
-    def run_sfincs_offshore(self):
+    def run_sfincs_offshore(self, ii: int):
         # Run offshore model(s)
 
         sfincs_exec = (
             self.database_input_path.parents[2] / "system" / "sfincs" / "sfincs.exe"
         )
 
-        for simulation_path in self.simulation_paths_offshore:
-            with cd(simulation_path):
-                sfincs_log = "sfincs.log"
-                with open(sfincs_log, "w") as log_handler:
-                    subprocess.run(sfincs_exec, stdout=log_handler)
+        simulation_path = self.simulation_paths_offshore[ii]
+        with cd(simulation_path):
+            sfincs_log = "sfincs.log"
+            with open(sfincs_log, "w") as log_handler:
+                subprocess.run(sfincs_exec, stdout=log_handler)
 
     def preprocess_sfincs(
         self,
@@ -383,7 +383,7 @@ class Hazard:
                 self.preprocess_sfincs_offshore(ds=ds, ii=ii)
                 # Run the actual SFINCS model
                 logging.info("Running offshore model...")
-                self.run_sfincs_offshore()
+                self.run_sfincs_offshore(ii=ii)
                 # add wl_ts to self
                 self.postprocess_sfincs_offshore(ii=ii)
 
@@ -588,7 +588,10 @@ class Hazard:
         path_in_offshore = base_path.joinpath(
             "static", "templates", self.site.attrs.sfincs.offshore_model
         )
-        event_dir = self.database_input_path / "events" / self.event.attrs.name
+        if self.event_mode == Mode.risk:
+            event_dir = self.database_input_path / "events" / self.event_set.attrs.name / self.event.attrs.name
+        else:
+            event_dir = self.database_input_path / "events" / self.event.attrs.name
 
         # Create folders for offshore model
         self.simulation_paths_offshore[ii].mkdir(parents=True, exist_ok=True)

--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -621,20 +621,33 @@ class Hazard:
         elif self.event.attrs.template == "Historical_hurricane":
             spw_name = "hurricane.spw"
             offshore_model.set_config_spw(spw_name=spw_name)
+            if event_dir.joinpath(spw_name).is_file():
+                logging.info(
+                    "Using existing hurricane meteo data."
+                )
+                # copy spw file from event directory to offshore model folder
+                shutil.copy2(
+                        event_dir.joinpath(spw_name), 
+                        self.simulation_paths_offshore[ii].joinpath(spw_name),
+                )
+            else:
+                logging.info(
+                    "Generating meteo input to the model from the hurricane track..."
+                )
+                offshore_model.add_spw_forcing(
+                    historical_hurricane=self.event,
+                    database_path=base_path,
+                    model_dir=self.simulation_paths_offshore[ii],
+                )
+                # save created spw file in the event directory
+                shutil.copy2(
+                        self.simulation_paths_offshore[ii].joinpath(spw_name),
+                        event_dir.joinpath(spw_name), 
+                )
+                logging.info("Finished generating meteo data from hurricane track.")
 
         # write sfincs model in output destination
         offshore_model.write_sfincs_model(path_out=self.simulation_paths_offshore[ii])
-
-        if self.event.attrs.template == "Historical_hurricane":
-            logging.info(
-                "Generating meteo input to the model from the hurricane track..."
-            )
-            offshore_model.add_spw_forcing(
-                historical_hurricane=self.event,
-                database_path=base_path,
-                model_dir=self.simulation_paths_offshore[ii],
-            )
-            logging.info("Finished generating meteo data from hurricane track.")
 
         del offshore_model
 


### PR DESCRIPTION
closes https://github.com/Deltares-research/FloodAdapt/issues/307 

This contains some fixes to also run offshore simulations in a probabilistic event set. And it reuses existing spiderweb files and will not create a new one every time a hurricane is run.

There is still an outstanding issue in the frontend to remove existing spiderweb files if a hurricane event is edited. But these backend changes are not dependent on the frontend issue and can already be reviewed and merged 