### PR TITLE
Make measure creation more general

### DIFF
--- a/flood_adapt/api/measures.py
+++ b/flood_adapt/api/measures.py
@@ -52,9 +52,7 @@ def create_measure(attrs: dict[str, Any], type: str, database: IDatabase = None)
         return Buyout.load_dict(attrs, database_path)
     elif type == "floodproof_properties":
         return FloodProof.load_dict(attrs, database_path)
-    elif type == "floodwall" or type == "thin_dam":
-        return FloodWall.load_dict(attrs, database_path)
-    elif type == "levee":
+    elif type == "floodwall" or type == "thin_dam" or type == "levee":
         return FloodWall.load_dict(attrs, database_path)
     elif type == "pump":
         return Pump.load_dict(attrs, database_path)

--- a/flood_adapt/api/measures.py
+++ b/flood_adapt/api/measures.py
@@ -25,21 +25,41 @@ def get_measure(name: str, database: IDatabase) -> IMeasure:
     return database.get_measure(name)
 
 
-def create_measure(attrs: dict[str, Any], type: str, database: IDatabase) -> IMeasure:
+def create_measure(attrs: dict[str, Any], type: str, database: IDatabase = None) -> IMeasure:
+    """Create a measure from a dictionary of attributes and a type string.
+    
+    Parameters
+    ----------
+    attrs : dict[str, Any]
+        Dictionary of attributes for the measure.
+    type : str
+        Type of measure to create.
+    database : IDatabase, optional
+        Database to use for creating the measure, by default None
+
+    Returns
+    -------
+    IMeasure
+        Measure object.    
+    """
+
+    # If a database is provided, use it to set the input path for the measure. Otherwise, set it to None.
+    database_path = database.input_path if database else None
+
     if type == "elevate_properties":
-        return Elevate.load_dict(attrs, database.input_path)
+        return Elevate.load_dict(attrs, database_path)
     elif type == "buyout_properties":
-        return Buyout.load_dict(attrs, database.input_path)
+        return Buyout.load_dict(attrs, database_path)
     elif type == "floodproof_properties":
-        return FloodProof.load_dict(attrs, database.input_path)
-    elif type == "floodwall":
-        return FloodWall.load_dict(attrs, database.input_path)
+        return FloodProof.load_dict(attrs, database_path)
+    elif type == "floodwall" or type == "thin_dam":
+        return FloodWall.load_dict(attrs, database_path)
     elif type == "levee":
-        return FloodWall.load_dict(attrs, database.input_path)
+        return FloodWall.load_dict(attrs, database_path)
     elif type == "pump":
-        return Pump.load_dict(attrs, database.input_path)
+        return Pump.load_dict(attrs, database_path)
     elif type == "water_square" or type == "total_storage" or type == "greening":
-        return GreenInfrastructure.load_dict(attrs, database.input_path)
+        return GreenInfrastructure.load_dict(attrs, database_path)
 
 
 def save_measure(measure: IMeasure, database: IDatabase) -> None:

--- a/flood_adapt/api/measures.py
+++ b/flood_adapt/api/measures.py
@@ -52,11 +52,11 @@ def create_measure(attrs: dict[str, Any], type: str, database: IDatabase = None)
         return Buyout.load_dict(attrs, database_path)
     elif type == "floodproof_properties":
         return FloodProof.load_dict(attrs, database_path)
-    elif type == "floodwall" or type == "thin_dam" or type == "levee":
+    elif type in ["floodwall", "thin_dam", "levee"]:
         return FloodWall.load_dict(attrs, database_path)
     elif type == "pump":
         return Pump.load_dict(attrs, database_path)
-    elif type == "water_square" or type == "total_storage" or type == "greening":
+    elif type in ["water_square", "total_storage", "greening"]:
         return GreenInfrastructure.load_dict(attrs, database_path)
 
 

--- a/flood_adapt/api/measures.py
+++ b/flood_adapt/api/measures.py
@@ -25,9 +25,11 @@ def get_measure(name: str, database: IDatabase) -> IMeasure:
     return database.get_measure(name)
 
 
-def create_measure(attrs: dict[str, Any], type: str, database: IDatabase = None) -> IMeasure:
+def create_measure(
+    attrs: dict[str, Any], type: str, database: IDatabase = None
+) -> IMeasure:
     """Create a measure from a dictionary of attributes and a type string.
-    
+
     Parameters
     ----------
     attrs : dict[str, Any]
@@ -40,7 +42,7 @@ def create_measure(attrs: dict[str, Any], type: str, database: IDatabase = None)
     Returns
     -------
     IMeasure
-        Measure object.    
+        Measure object.
     """
 
     # If a database is provided, use it to set the input path for the measure. Otherwise, set it to None.

--- a/flood_adapt/api/measures.py
+++ b/flood_adapt/api/measures.py
@@ -54,7 +54,7 @@ def create_measure(attrs: dict[str, Any], type: str, database: IDatabase = None)
         return FloodProof.load_dict(attrs, database_path)
     elif type in ["floodwall", "thin_dam", "levee"]:
         return FloodWall.load_dict(attrs, database_path)
-    elif type == "pump":
+    elif type in ["pump", "culvert"]:
         return Pump.load_dict(attrs, database_path)
     elif type in ["water_square", "total_storage", "greening"]:
         return GreenInfrastructure.load_dict(attrs, database_path)

--- a/flood_adapt/object_model/direct_impact/measure/buyout.py
+++ b/flood_adapt/object_model/direct_impact/measure/buyout.py
@@ -15,7 +15,7 @@ class Buyout(ImpactMeasure, IBuyout):
     """Subclass of ImpactMeasure describing the measure of buying-out buildings"""
 
     attrs: BuyoutModel
-    database_input_path: Union[str, os.PathLike]
+    database_input_path: Union[str, os.PathLike, None]
 
     @staticmethod
     def load_file(filepath: Union[str, os.PathLike]) -> IBuyout:
@@ -31,7 +31,7 @@ class Buyout(ImpactMeasure, IBuyout):
 
     @staticmethod
     def load_dict(
-        data: dict[str, Any], database_input_path: Union[str, os.PathLike]
+        data: dict[str, Any], database_input_path: Union[str, os.PathLike, None]
     ) -> IBuyout:
         """create Buyout from object, e.g. when initialized from GUI"""
 

--- a/flood_adapt/object_model/direct_impact/measure/elevate.py
+++ b/flood_adapt/object_model/direct_impact/measure/elevate.py
@@ -15,7 +15,7 @@ class Elevate(ImpactMeasure, IElevate):
     """Subclass of ImpactMeasure describing the measure of elevating buildings by a specific height"""
 
     attrs: ElevateModel
-    database_input_path: Union[str, os.PathLike, None]
+    database_input_path: Union[str, os.PathLike]
 
     @staticmethod
     def load_file(filepath: Union[str, os.PathLike]) -> IElevate:
@@ -31,7 +31,7 @@ class Elevate(ImpactMeasure, IElevate):
 
     @staticmethod
     def load_dict(
-        data: dict[str, Any], database_input_path: Union[str, os.PathLike, None]
+        data: dict[str, Any], database_input_path: Union[str, os.PathLike]
     ) -> IElevate:
         """create Elevate from object, e.g. when initialized from GUI"""
 

--- a/flood_adapt/object_model/direct_impact/measure/elevate.py
+++ b/flood_adapt/object_model/direct_impact/measure/elevate.py
@@ -15,7 +15,7 @@ class Elevate(ImpactMeasure, IElevate):
     """Subclass of ImpactMeasure describing the measure of elevating buildings by a specific height"""
 
     attrs: ElevateModel
-    database_input_path: Union[str, os.PathLike]
+    database_input_path: Union[str, os.PathLike, None]
 
     @staticmethod
     def load_file(filepath: Union[str, os.PathLike]) -> IElevate:
@@ -31,7 +31,7 @@ class Elevate(ImpactMeasure, IElevate):
 
     @staticmethod
     def load_dict(
-        data: dict[str, Any], database_input_path: Union[str, os.PathLike]
+        data: dict[str, Any], database_input_path: Union[str, os.PathLike, None]
     ) -> IElevate:
         """create Elevate from object, e.g. when initialized from GUI"""
 

--- a/flood_adapt/object_model/direct_impact/measure/floodproof.py
+++ b/flood_adapt/object_model/direct_impact/measure/floodproof.py
@@ -15,7 +15,7 @@ class FloodProof(ImpactMeasure, IFloodProof):
     """Subclass of ImpactMeasure describing the measure of flood-proof buildings"""
 
     attrs: FloodProofModel
-    database_input_path: Union[str, os.PathLike]
+    database_input_path: Union[str, os.PathLike, None]
 
     @staticmethod
     def load_file(filepath: Union[str, os.PathLike]) -> IFloodProof:
@@ -31,7 +31,7 @@ class FloodProof(ImpactMeasure, IFloodProof):
 
     @staticmethod
     def load_dict(
-        data: dict[str, Any], database_input_path: Union[str, os.PathLike]
+        data: dict[str, Any], database_input_path: Union[str, os.PathLike, None]
     ) -> IFloodProof:
         """create FloodProof from object, e.g. when initialized from GUI"""
 

--- a/flood_adapt/object_model/hazard/measure/floodwall.py
+++ b/flood_adapt/object_model/hazard/measure/floodwall.py
@@ -18,7 +18,7 @@ class FloodWall(HazardMeasure, IFloodWall):
     """Subclass of HazardMeasure describing the measure of building a floodwall with a specific height"""
 
     attrs: FloodWallModel
-    database_input_path: Union[str, os.PathLike]
+    database_input_path: Union[str, os.PathLike, None]
 
     @staticmethod
     def load_file(filepath: Union[str, os.PathLike]) -> IFloodWall:
@@ -34,7 +34,7 @@ class FloodWall(HazardMeasure, IFloodWall):
 
     @staticmethod
     def load_dict(
-        data: dict[str, Any], database_input_path: Union[str, os.PathLike]
+        data: dict[str, Any], database_input_path: Union[str, os.PathLike, None]
     ) -> IFloodWall:
         """create Floodwall from object, e.g. when initialized from GUI"""
 

--- a/flood_adapt/object_model/hazard/measure/green_infrastructure.py
+++ b/flood_adapt/object_model/hazard/measure/green_infrastructure.py
@@ -22,7 +22,7 @@ class GreenInfrastructure(HazardMeasure, IGreenInfrastructure):
     """Subclass of HazardMeasure describing the measure of urban green infrastructure with a specific storage volume that is calculated based on are, storage height and percentage of area coverage"""
 
     attrs: GreenInfrastructureModel
-    database_input_path: Union[str, os.PathLike]
+    database_input_path: Union[str, os.PathLike, None]
 
     @staticmethod
     def load_file(filepath: Union[str, os.PathLike]) -> IGreenInfrastructure:
@@ -38,7 +38,7 @@ class GreenInfrastructure(HazardMeasure, IGreenInfrastructure):
 
     @staticmethod
     def load_dict(
-        data: dict[str, Any], database_input_path: Union[str, os.PathLike]
+        data: dict[str, Any], database_input_path: Union[str, os.PathLike, None]
     ) -> IGreenInfrastructure:
         """create Green Infrastructure from object, e.g. when initialized from GUI"""
 

--- a/flood_adapt/object_model/hazard/measure/pump.py
+++ b/flood_adapt/object_model/hazard/measure/pump.py
@@ -18,7 +18,7 @@ class Pump(HazardMeasure, IPump):
     """Subclass of HazardMeasure describing the measure of building a floodwall with a specific height"""
 
     attrs: PumpModel
-    database_input_path: Union[str, os.PathLike]
+    database_input_path: Union[str, os.PathLike, None]
 
     @staticmethod
     def load_file(filepath: Union[str, os.PathLike]) -> IPump:
@@ -34,7 +34,7 @@ class Pump(HazardMeasure, IPump):
 
     @staticmethod
     def load_dict(
-        data: dict[str, Any], database_input_path: Union[str, os.PathLike]
+        data: dict[str, Any], database_input_path: Union[str, os.PathLike, None]
     ) -> IPump:
         """create Floodwall from object, e.g. when initialized from GUI"""
 

--- a/flood_adapt/object_model/interface/measures.py
+++ b/flood_adapt/object_model/interface/measures.py
@@ -27,10 +27,12 @@ class HazardType(str, Enum):
     """Class describing the accepted input for the variable 'type' in HazardMeasure"""
 
     floodwall = "floodwall"
-    thin_dam = "thin_dam"  # same functionality as floodwall
-    levee = "levee"  # same functionality as floodwall
+    thin_dam = "thin_dam"  # For now, same functionality as floodwall TODO: Add thin dam functionality
+    levee = "levee"  # For now, same functionality as floodwall TODO: Add levee functionality
     pump = "pump"
-    culvert = "culvert"  # same functionality as pump
+    culvert = (
+        "culvert"  # For now, same functionality as pump TODO: Add culvert functionality
+    )
     water_square = "water_square"
     greening = "greening"
     total_storage = "total_storage"

--- a/flood_adapt/object_model/interface/measures.py
+++ b/flood_adapt/object_model/interface/measures.py
@@ -30,7 +30,7 @@ class HazardType(str, Enum):
     thin_dam = "thin_dam"  # same functionality as floodwall
     levee = "levee"  # same functionality as floodwall
     pump = "pump"
-    culvert = "culvert" # same functionality as pump
+    culvert = "culvert"  # same functionality as pump
     water_square = "water_square"
     greening = "greening"
     total_storage = "total_storage"

--- a/flood_adapt/object_model/interface/measures.py
+++ b/flood_adapt/object_model/interface/measures.py
@@ -27,8 +27,10 @@ class HazardType(str, Enum):
     """Class describing the accepted input for the variable 'type' in HazardMeasure"""
 
     floodwall = "floodwall"
+    thin_dam = "thin_dam"  # same functionality as floodwall
     levee = "levee"  # same functionality as floodwall
     pump = "pump"
+    culvert = "culvert" # same functionality as pump
     water_square = "water_square"
     greening = "greening"
     total_storage = "total_storage"


### PR DESCRIPTION
Add the option of setting the database input path to a none. It doesn't change anything for FloodAdapt but for de modelbuider (where there is no database), it can now also be used to make models. And also add the thin dam and culvert options