### PR TITLE
341 fix slr in event sets

### DIFF
--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -226,31 +226,6 @@ class Hazard:
 
     # no write function is needed since this is only used internally
 
-    def add_wl_ts(self):
-        """adds total water level timeseries to hazard object"""
-        # generating total time series made of tide, slr (and water level offset for synthetic event),
-        # only for Synthetic and historical from nearshore, otherwise these come from the offshore model
-        for ii, event in enumerate(self.event_list):
-            if self.event.attrs.template == "Synthetic":
-                self.event.add_tide_and_surge_ts()
-                # add water level offset due to historic SLR for synthetic event
-                self.wl_ts = (
-                    self.event.tide_surge_ts
-                    + self.site.attrs.slr.vertical_offset.convert(
-                        self.site.attrs.gui.default_length_units
-                    )
-                )
-            elif self.event.attrs.template == "Historical_nearshore":
-                # water level offset due to historic SLR already included in observations
-                self.wl_ts = self.event.tide_surge_ts
-            # In both cases add SLR
-            self.wl_ts[1] = self.wl_ts[
-                1
-            ] + self.physical_projection.attrs.sea_level_rise.convert(
-                self.site.attrs.gui.default_length_units
-            )
-        return self
-
     @staticmethod
     def get_event_object(event_path):
         mode = Event.get_mode(event_path)
@@ -371,16 +346,34 @@ class Hazard:
 
             # Generate and change water level boundary condition
             template = self.event.attrs.template
+
             if template == "Synthetic" or template == "Historical_nearshore":
                 # generate hazard water level bc incl SLR (in the offshore model these are already included)
                 # returning wl referenced to MSL
-                self.add_wl_ts()
+                if self.event.attrs.template == "Synthetic":
+                    self.event.add_tide_and_surge_ts()
+                    # add water level offset due to historic SLR for synthetic event
+                    wl_ts = (
+                        self.event.tide_surge_ts
+                        + self.site.attrs.slr.vertical_offset.convert(
+                            self.site.attrs.gui.default_length_units
+                        )
+                    )
+                elif self.event.attrs.template == "Historical_nearshore":
+                    # water level offset due to historic SLR already included in observations
+                    wl_ts = self.event.tide_surge_ts
+                # In both cases (Synthetic and Historical nearshore) add SLR
+                wl_ts[1] = wl_ts[
+                    1
+                ] + self.physical_projection.attrs.sea_level_rise.convert(
+                    self.site.attrs.gui.default_length_units
+                )
                 # unit conversion to metric units (not needed for water levels coming from the offshore model, see below)
                 gui_units = UnitfulLength(
                     value=1.0, units=self.site.attrs.gui.default_length_units
                 )
                 conversion_factor = gui_units.convert(UnitTypesLength("meters"))
-                self.wl_ts = conversion_factor * self.wl_ts
+                self.wl_ts = conversion_factor * wl_ts
             elif (
                 template == "Historical_offshore" or template == "Historical_hurricane"
             ):

--- a/tests/test_integrator/test_hazard_run.py
+++ b/tests/test_integrator/test_hazard_run.py
@@ -275,7 +275,7 @@ def test_preprocess_prob_eventset(test_db: None):
         / "charleston"
         / "output"
         / "Scenarios"
-        / "current_test_set_no_measures"
+        / test_scenario.attrs.name
         / "Flooding"
         / "simulations"
         / "event_0001"
@@ -287,7 +287,7 @@ def test_preprocess_prob_eventset(test_db: None):
         / "charleston"
         / "output"
         / "Scenarios"
-        / "current_test_set_no_measures"
+        / test_scenario.attrs.name
         / "Flooding"
         / "simulations"
         / "event_0039"
@@ -300,8 +300,8 @@ def test_preprocess_prob_eventset(test_db: None):
 
     # add SLR
 
-    test_scenario.attrs.projection = "SLR_1ft"
-    test_scenario.attrs.name = "SLR_1ft_test_set_no_measures"
+    test_scenario.attrs.projection = "SLR_2ft"
+    test_scenario.attrs.name = "SLR_2ft_test_set_no_measures"
     test_scenario.init_object_model()
     slr = test_scenario.direct_impacts.hazard.physical_projection.attrs.sea_level_rise
     test_scenario.direct_impacts.hazard.preprocess_models()
@@ -310,7 +310,7 @@ def test_preprocess_prob_eventset(test_db: None):
         / "charleston"
         / "output"
         / "Scenarios"
-        / "SLR_1ft_test_set_no_measures"
+        / test_scenario.attrs.name
         / "Flooding"
         / "simulations"
         / "event_0001"

--- a/tests/test_integrator/test_hazard_run.py
+++ b/tests/test_integrator/test_hazard_run.py
@@ -11,7 +11,10 @@ import xarray as xr
 from flood_adapt.object_model.hazard.measure.green_infrastructure import (
     GreenInfrastructure,
 )
-from flood_adapt.object_model.io.unitfulvalue import UnitfulDischarge, UnitfulIntensity
+from flood_adapt.object_model.io.unitfulvalue import (
+    UnitfulDischarge,
+    UnitfulIntensity,
+)
 from flood_adapt.object_model.scenario import Scenario
 
 test_database = Path().absolute() / "tests" / "test_database"
@@ -294,6 +297,30 @@ def test_preprocess_prob_eventset(test_db: None):
     assert bzs_file1.is_file()
     assert bzs_file2.is_file()
     assert ~filecmp.cmp(bzs_file1, bzs_file2)
+
+    # add SLR
+
+    test_scenario.attrs.projection = "SLR_1ft"
+    test_scenario.attrs.name = "SLR_1ft_test_set_no_measures"
+    test_scenario.init_object_model()
+    slr = test_scenario.direct_impacts.hazard.physical_projection.attrs.sea_level_rise
+    test_scenario.direct_impacts.hazard.preprocess_models()
+    bzs_file1_slr = (
+        test_database
+        / "charleston"
+        / "output"
+        / "Scenarios"
+        / "SLR_1ft_test_set_no_measures"
+        / "Flooding"
+        / "simulations"
+        / "event_0001"
+        / "overland"
+        / "sfincs.bzs"
+    )
+    df = pd.read_csv(bzs_file1, header=None, index_col=0, delim_whitespace=True)
+    df_slr = pd.read_csv(bzs_file1_slr, header=None, index_col=0, delim_whitespace=True)
+
+    assert np.abs((df_slr[1] - df[1]).mean() - slr.convert("meters")) < 0.01
 
 
 def test_preprocess_rainfall_increase(test_db):

--- a/tests/test_object_model/test_scenarios.py
+++ b/tests/test_object_model/test_scenarios.py
@@ -70,30 +70,6 @@ def test_hazard_load():
     assert isinstance(hazard.event_list[0].attrs.tide, TideModel)
 
 
-def test_hazard_wl(test_db):
-    test_toml = (
-        test_database
-        / "charleston"
-        / "input"
-        / "scenarios"
-        / "current_extreme12ft_no_measures"
-        / "current_extreme12ft_no_measures.toml"
-    )
-
-    assert test_toml.is_file()
-
-    scenario = Scenario.load_file(test_toml)
-    scenario.init_object_model()
-
-    hazard = scenario.direct_impacts.hazard
-
-    hazard.add_wl_ts()
-
-    assert isinstance(hazard.wl_ts, pd.DataFrame)
-    assert len(hazard.wl_ts) > 1
-    assert isinstance(hazard.wl_ts.index, pd.DatetimeIndex)
-
-
 def test_scs_rainfall(test_db):
     test_toml = (
         test_database


### PR DESCRIPTION
That was a very peculiar error where I had added n * SLR (with n being the number of synthetic or nearshore_historical events). In the probabilistic event set we have 60 nearshore_historical events so instead of adding 1ft of SLR FloodAdapt added 60ft. Hence the crazy floodmap Kathryn got.

This happened in the function hazard.add_wl(), which was actually only called once in hazard.preprocess_sfincs(). Both functions looped over all events in the event set and this is where I must have been adding SLR n times. I removed the function hazard.add_wl() since it just made it confusing and led to this error and moved its functionality directly into hazard.preprocess_sfincs(). The fix also includes an updated test to check whether SLR has been added correctly.