### PR TITLE
File handles closing

### DIFF
--- a/flood_adapt/dbs_controller.py
+++ b/flood_adapt/dbs_controller.py
@@ -109,7 +109,9 @@ class Database(IDatabase):
             "static", "templates", self.site.attrs.sfincs.overland_model
         )
         model = SfincsAdapter(model_root=path_in, site=self.site)
-        return model.get_model_boundary()
+        bnd = model.get_model_boundary()
+        del model
+        return bnd
 
     def get_obs_points(self) -> GeoDataFrame:
         """Get the observation points from the flood hazard model"""
@@ -1568,7 +1570,7 @@ class Database(IDatabase):
                 f"RP_{return_period:04d}_maps.nc",
             )
             zsmax = xr.open_dataset(file_path)["risk_map"][:, :].to_numpy().T
-
+        # Use garbage collector to ensure file handles are properly cleaned up
         return zsmax
 
     def get_fiat_footprints(self, scenario_name: str) -> GeoDataFrame:

--- a/flood_adapt/dbs_controller.py
+++ b/flood_adapt/dbs_controller.py
@@ -1570,7 +1570,6 @@ class Database(IDatabase):
                 f"RP_{return_period:04d}_maps.nc",
             )
             zsmax = xr.open_dataset(file_path)["risk_map"][:, :].to_numpy().T
-        # Use garbage collector to ensure file handles are properly cleaned up
         return zsmax
 
     def get_fiat_footprints(self, scenario_name: str) -> GeoDataFrame:

--- a/flood_adapt/integrator/sfincs_adapter.py
+++ b/flood_adapt/integrator/sfincs_adapter.py
@@ -43,11 +43,8 @@ class SfincsAdapter:
         Args:
             model_root (str, optional): Root directory of overland sfincs model. Defaults to None.
         """
-        # Check if model root exists
-        # if validate_existence_root_folder(model_root):
-        #    self.model_root = model_root
-
         self.sfincs_logger = logging.getLogger(__name__)
+        self.sfincs_logger.handlers = []  # To ensure logging file path has reset
         self.sf_model = SfincsModel(
             root=model_root, mode="r+", logger=self.sfincs_logger
         )

--- a/flood_adapt/integrator/sfincs_adapter.py
+++ b/flood_adapt/integrator/sfincs_adapter.py
@@ -1,3 +1,4 @@
+import gc
 import logging
 import os
 from pathlib import Path
@@ -57,6 +58,7 @@ class SfincsAdapter:
         # Close the log file associated with the logger
         for handler in self.sfincs_logger.handlers:
             handler.close()
+        gc.collect()
 
     def set_timing(self, event: EventModel):
         """Changes model reference times based on event time series."""

--- a/flood_adapt/integrator/sfincs_adapter.py
+++ b/flood_adapt/integrator/sfincs_adapter.py
@@ -55,6 +55,7 @@ class SfincsAdapter:
         # Close the log file associated with the logger
         for handler in self.sfincs_logger.handlers:
             handler.close()
+        # Use garbage collector to ensure file handles are properly cleaned up
         gc.collect()
 
     def set_timing(self, event: EventModel):


### PR DESCRIPTION
There were issues with files that were staying after the SFincsAdapter was run.

- One issue was connected with the netcdf files staying open, which was resolved by using a garbage collector whenever the a SfincsAdapter is deleted.
- The second issue was with the log file handler for the SfincsAdapter which was sometimes using the last handle (which could even be a diffent SFINCS model). This was resolved by resetting the loggers file handler every time a new SfincsAdapter object is initialized.