### PR TITLE
355 option to delete simulation folders for sfincs and fiat

### DIFF
--- a/flood_adapt/api/output.py
+++ b/flood_adapt/api/output.py
@@ -62,7 +62,7 @@ def get_obs_point_timeseries(name: str, database: IDatabase) -> gpd.GeoDataFrame
     hazard = database.get_scenario(name).direct_impacts.hazard
 
     # Check if the scenario has run
-    if not hazard.sfincs_has_run_check():
+    if not hazard.has_run_check():
         raise ValueError(
             f"Scenario {name} has not been run. Please run the scenario first."
         )

--- a/flood_adapt/dbs_controller.py
+++ b/flood_adapt/dbs_controller.py
@@ -1551,32 +1551,33 @@ class Database(IDatabase):
         scenario_name: str,
         return_period: int = None,
     ) -> np.array:
-        """returns an array with the maximum water levels of the SFINCS simulation
+        """Returns an array with the maximum water levels during an event
 
         Parameters
         ----------
         scenario_name : str
             name of scenario
+        return_period : int, optional
+            return period in years, by default None
 
         Returns
         -------
-        _type_
-            _description_
+        np.array
+            2D map of maximum water levels
         """
         # If single event read with hydromt-sfincs
         if not return_period:
-            model_path = self.input_path.parent.joinpath(
+            map_path = self.input_path.parent.joinpath(
                 "output",
                 "Scenarios",
                 scenario_name,
                 "Flooding",
-                "simulations",
-                self.site.attrs.sfincs.overland_model,
+                "max_water_level_map.nc",
             )
-            model = SfincsAdapter(model_root=model_path, site=self.site)
+            map = xr.open_dataarray(map_path)
 
-            zsmax = model.read_zsmax().to_numpy()
-            del model
+            zsmax = map.to_numpy()
+
         else:
             file_path = self.input_path.parent.joinpath(
                 "output",
@@ -1589,6 +1590,18 @@ class Database(IDatabase):
         return zsmax
 
     def get_fiat_footprints(self, scenario_name: str) -> GeoDataFrame:
+        """Return a geodataframe of the impacts at the footprint level.
+
+        Parameters
+        ----------
+        scenario_name : str
+            name of scenario
+
+        Returns
+        -------
+        GeoDataFrame
+            impacts at footprint level
+        """
         out_path = self.input_path.parent.joinpath(
             "output", "Scenarios", scenario_name, "Impacts"
         )
@@ -1598,6 +1611,18 @@ class Database(IDatabase):
         return gdf
 
     def get_roads(self, scenario_name: str) -> GeoDataFrame:
+        """Return a geodataframe of the impacts at roads.
+
+        Parameters
+        ----------
+        scenario_name : str
+            name of scenario
+
+        Returns
+        -------
+        GeoDataFrame
+            Impacts at roads
+        """
         out_path = self.input_path.parent.joinpath(
             "output", "Scenarios", scenario_name, "Impacts"
         )
@@ -1709,7 +1734,7 @@ class Database(IDatabase):
                     "output", "Scenarios", scenario.attrs.name, "Flooding"
                 )
                 if (
-                    scn.direct_impacts.hazard.sfincs_has_run_check()
+                    scn.direct_impacts.hazard.has_run_check()
                 ):  # only copy results if the hazard model has actually finished
                     shutil.copytree(path_0, path_new, dirs_exist_ok=True)
                     print(

--- a/flood_adapt/integrator/sfincs_adapter.py
+++ b/flood_adapt/integrator/sfincs_adapter.py
@@ -452,6 +452,7 @@ class SfincsAdapter:
         """Read zsmax file and return absolute maximum water level over entire simulation"""
         self.sf_model.read_results()
         zsmax = self.sf_model.results["zsmax"].max(dim="timemax")
+        zsmax.attrs["units"] = "m"
         return zsmax
 
     def read_zs_points(self):

--- a/flood_adapt/object_model/direct_impacts.py
+++ b/flood_adapt/object_model/direct_impacts.py
@@ -330,7 +330,10 @@ class DirectImpacts:
 
         # If site config is set to not keep FIAT simulation, then delete folder
         if not self.site_info.attrs.fiat.save_simulation:
-            shutil.rmtree(self.fiat_path)
+            try:
+                shutil.rmtree(self.fiat_path)
+            except OSError as e_info:
+                logging.warning(f"{e_info}\nCould not delete {self.fiat_path}.")
 
     def _create_roads(self, fiat_results_df):
         logging.info("Saving road impacts...")

--- a/flood_adapt/object_model/direct_impacts.py
+++ b/flood_adapt/object_model/direct_impacts.py
@@ -63,9 +63,22 @@ class DirectImpacts:
         # Define results path
         self.impacts_path = self.results_path.joinpath("Impacts")
         self.fiat_path = self.impacts_path.joinpath("fiat_model")
-        self.has_run = self.fiat_has_run_check()
+        self.has_run = self.has_run_check()
 
-    def fiat_has_run_check(self):
+    def has_run_check(self) -> bool:
+        """Checks if the direct impact has been run.
+
+        Returns
+        -------
+        bool
+            _description_
+        """
+
+        check = self.impacts_path.joinpath(f"Impacts_detailed_{self.name}.csv").exists()
+
+        return check
+
+    def fiat_has_run_check(self) -> bool:
         """Checks if fiat has run as expected
 
         Returns
@@ -277,6 +290,9 @@ class DirectImpacts:
 
     def postprocess_fiat(self):
         # Postprocess the FIAT results
+        if not self.fiat_has_run_check():
+            raise RuntimeError("Delft-FIAT did not run successfully!")
+
         # First move and rename fiat output csv
         fiat_results_path = self.impacts_path.joinpath(
             f"Impacts_detailed_{self.name}.csv"
@@ -312,10 +328,9 @@ class DirectImpacts:
 
         logging.info("Post-processing complete!")
 
-        # TODO add this when hydromt logger issue solution has been merged
         # If site config is set to not keep FIAT simulation, then delete folder
-        # if not self.site_info.attrs.fiat.save_simulation:
-        # shutil.rmtree(self.fiat_path)
+        if not self.site_info.attrs.fiat.save_simulation:
+            shutil.rmtree(self.fiat_path)
 
     def _create_roads(self, fiat_results_df):
         logging.info("Saving road impacts...")

--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
-from typing import List, Union
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -144,12 +144,12 @@ class Hazard:
         """
         self._get_flood_map_path()
 
-        has_run = False
+        # Iterate to all needed flood map files to check if they exists
+        checks = []
+        for map in self.flood_map_path:
+            checks.append(map.exists())
 
-        if self.flood_map_path:
-            has_run = True
-
-        return has_run
+        return all(checks)
 
     def sfincs_has_run_check(self) -> bool:
         """checks if the hazard has been already run"""
@@ -692,13 +692,14 @@ class Hazard:
         """_summary_"""
         results_path = self.results_dir
         mode = self.event_mode
-        map_fn: List[Union[str, Path]] = []
 
         if mode == Mode.single_event:
-            map_fn = list(results_path.glob("max_water_level_map.nc"))
+            map_fn = [results_path.joinpath("max_water_level_map.nc")]
 
         elif mode == Mode.risk:
-            map_fn = list(results_path.glob("RP_*.nc"))
+            map_fn = []
+            for rp in self.site.attrs.risk.return_periods:
+                map_fn.append(results_path.joinpath(f"RP_{rp:04d}_maps.nc"))
 
         self.flood_map_path = map_fn
 

--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -272,8 +272,8 @@ class Hazard:
             if os.path.exists(sim_path):
                 try:
                     shutil.rmtree(sim_path)
-                except WindowsError:
-                    pass
+                except OSError as e_info:
+                    logging.warning(f"{e_info}\nCould not delete {sim_path}.")
 
     def run_sfincs(self):
         # Run new model(s)

--- a/flood_adapt/object_model/interface/site.py
+++ b/flood_adapt/object_model/interface/site.py
@@ -42,7 +42,7 @@ class SfincsModel(BaseModel):
     overland_model: str
     ambient_air_pressure: float
     floodmap_units: UnitTypesLength
-    save_simulation: bool
+    save_simulation: Optional[bool] = False
 
 
 class VerticalReferenceModel(BaseModel):

--- a/flood_adapt/object_model/scenario.py
+++ b/flood_adapt/object_model/scenario.py
@@ -87,7 +87,7 @@ class Scenario(IScenario):
         else:
             print(f"Hazard for scenario '{self.attrs.name}' has already been run.")
         if not self.direct_impacts.has_run:
-            self.direct_impacts.preprocess_models()  # TODO: separate preprocessing and running of impact models
+            self.direct_impacts.preprocess_models()
             self.direct_impacts.run_models()
             self.direct_impacts.postprocess_models()
         else:

--- a/tests/test_object_model/test_benefits.py
+++ b/tests/test_object_model/test_benefits.py
@@ -120,9 +120,7 @@ def test_run_benefit_analysis(test_db):
     benefit.cba()
 
     # Read results
-    results_path = (
-        test_database / "charleston" / "output" / "Benefits" / benefit.attrs.name
-    )
+    results_path = test_db.output_path / "Benefits" / benefit.attrs.name
     with open(results_path.joinpath("results.toml"), mode="rb") as fp:
         results = tomli.load(fp)
 
@@ -203,9 +201,7 @@ def test_run_CBA(test_db):
     benefit.cba()
 
     # Read results
-    results_path = (
-        test_database / "charleston" / "output" / "Benefits" / benefit.attrs.name
-    )
+    results_path = test_db.output_path / "Benefits" / benefit.attrs.name
     with open(results_path.joinpath("results.toml"), mode="rb") as fp:
         results = tomli.load(fp)
 


### PR DESCRIPTION
- Added a netcdf file with the max water levels in the Flooding folder of the results for each scenario to be used instead of the actual simulation
- Implemented the deletion of the simulation folders for SFINCS and FIAT if it is chosen in the site.toml
- Changed the has_run checks for both Hazard and Direct_Impacts to ensure only post-processed output is checked.