### PR TITLE
using z-value in floodwall from shp file 

### DIFF
--- a/flood_adapt/integrator/sfincs_adapter.py
+++ b/flood_adapt/integrator/sfincs_adapter.py
@@ -298,7 +298,15 @@ class SfincsAdapter:
         ):  # The column name and the choice if uniform value or from shape file should be an option in the GUI
             gdf_floodwall["z"] = floodwall.elevation.convert(UnitTypesLength("meters"))
         else:
-            heights = [float(UnitfulLength(value=float(height),units=self.site.attrs.gui.default_length_units).convert(UnitTypesLength("meters"))) for height in gdf_floodwall["z"]]
+            heights = [
+                float(
+                    UnitfulLength(
+                        value=float(height),
+                        units=self.site.attrs.gui.default_length_units,
+                    ).convert(UnitTypesLength("meters"))
+                )
+                for height in gdf_floodwall["z"]
+            ]
             gdf_floodwall["z"] = heights
         # par1 is the overflow coefficient for weirs
         gdf_floodwall["par1"] = 0.6

--- a/flood_adapt/integrator/sfincs_adapter.py
+++ b/flood_adapt/integrator/sfincs_adapter.py
@@ -297,6 +297,8 @@ class SfincsAdapter:
             "z" not in gdf_floodwall.columns
         ):  # The column name and the choice if uniform value or from shape file should be an option in the GUI
             gdf_floodwall["z"] = floodwall.elevation.convert(UnitTypesLength("meters"))
+        else:
+            gdf_floodwall["z"] = gdf_floodwall["z"].convert(UnitTypesLength("meters"))
         gdf_floodwall["par1"] = 0.6
 
         # HydroMT function: create floodwall

--- a/flood_adapt/integrator/sfincs_adapter.py
+++ b/flood_adapt/integrator/sfincs_adapter.py
@@ -291,7 +291,7 @@ class SfincsAdapter:
 
         # Add floodwall attributes to geodataframe
         gdf_floodwall["name"] = floodwall.name
-        if (gdf_floodwall.geometry.type =="MultiLineString").any():
+        if (gdf_floodwall.geometry.type == "MultiLineString").any():
             gdf_floodwall = gdf_floodwall.explode()
         if "z" not in gdf_floodwall.columns:
             gdf_floodwall["z"] = floodwall.elevation.convert(UnitTypesLength("meters"))

--- a/flood_adapt/integrator/sfincs_adapter.py
+++ b/flood_adapt/integrator/sfincs_adapter.py
@@ -298,7 +298,9 @@ class SfincsAdapter:
         ):  # The column name and the choice if uniform value or from shape file should be an option in the GUI
             gdf_floodwall["z"] = floodwall.elevation.convert(UnitTypesLength("meters"))
         else:
-            gdf_floodwall["z"] = gdf_floodwall["z"].convert(UnitTypesLength("meters"))
+            heights = [float(UnitfulLength(value=float(height),units=self.site.attrs.gui.default_length_units).convert(UnitTypesLength("meters"))) for height in gdf_floodwall["z"]]
+            gdf_floodwall["z"] = heights
+        # par1 is the overflow coefficient for weirs
         gdf_floodwall["par1"] = 0.6
 
         # HydroMT function: create floodwall

--- a/flood_adapt/integrator/sfincs_adapter.py
+++ b/flood_adapt/integrator/sfincs_adapter.py
@@ -293,8 +293,8 @@ class SfincsAdapter:
         gdf_floodwall["name"] = floodwall.name
         if (gdf_floodwall.geometry.type == "MultiLineString").any():
             gdf_floodwall = gdf_floodwall.explode()
-        #TODO: Choice of height data from file or uniform height and column name with height data should be adjustable in the GUI
-        try: 
+        # TODO: Choice of height data from file or uniform height and column name with height data should be adjustable in the GUI
+        try:
             heights = [
                 float(
                     UnitfulLength(
@@ -311,7 +311,7 @@ class SfincsAdapter:
                 Using uniform height of {floodwall.elevation.convert(UnitTypesLength("meters"))} meters instead."""
             )
             gdf_floodwall["z"] = floodwall.elevation.convert(UnitTypesLength("meters"))
-            
+
         # par1 is the overflow coefficient for weirs
         gdf_floodwall["par1"] = 0.6
 

--- a/flood_adapt/integrator/sfincs_adapter.py
+++ b/flood_adapt/integrator/sfincs_adapter.py
@@ -291,7 +291,10 @@ class SfincsAdapter:
 
         # Add floodwall attributes to geodataframe
         gdf_floodwall["name"] = floodwall.name
-        gdf_floodwall["z"] = floodwall.elevation.convert(UnitTypesLength("meters"))
+        if (gdf_floodwall.geometry.type =="MultiLineString").any():
+            gdf_floodwall = gdf_floodwall.explode()
+        if "z" not in gdf_floodwall.columns:
+            gdf_floodwall["z"] = floodwall.elevation.convert(UnitTypesLength("meters"))
         gdf_floodwall["par1"] = 0.6
 
         # HydroMT function: create floodwall

--- a/flood_adapt/integrator/sfincs_adapter.py
+++ b/flood_adapt/integrator/sfincs_adapter.py
@@ -293,7 +293,9 @@ class SfincsAdapter:
         gdf_floodwall["name"] = floodwall.name
         if (gdf_floodwall.geometry.type == "MultiLineString").any():
             gdf_floodwall = gdf_floodwall.explode()
-        if "z" not in gdf_floodwall.columns:
+        if (
+            "z" not in gdf_floodwall.columns
+        ):  # The column name and the choice if uniform value or from shape file should be an option in the GUI
             gdf_floodwall["z"] = floodwall.elevation.convert(UnitTypesLength("meters"))
         gdf_floodwall["par1"] = 0.6
 

--- a/flood_adapt/integrator/sfincs_adapter.py
+++ b/flood_adapt/integrator/sfincs_adapter.py
@@ -305,6 +305,7 @@ class SfincsAdapter:
                 for height in gdf_floodwall["z"]
             ]
             gdf_floodwall["z"] = heights
+            logging.info("Using floodwall height from shape file.")
         except Exception:
             logging.warning(
                 f"""Could not use height data from file due to missing ""z""-column or missing values therein.\n

--- a/flood_adapt/integrator/sfincs_adapter.py
+++ b/flood_adapt/integrator/sfincs_adapter.py
@@ -293,11 +293,8 @@ class SfincsAdapter:
         gdf_floodwall["name"] = floodwall.name
         if (gdf_floodwall.geometry.type == "MultiLineString").any():
             gdf_floodwall = gdf_floodwall.explode()
-        if (
-            "z" not in gdf_floodwall.columns
-        ):  # The column name and the choice if uniform value or from shape file should be an option in the GUI
-            gdf_floodwall["z"] = floodwall.elevation.convert(UnitTypesLength("meters"))
-        else:
+        #TODO: Choice of height data from file or uniform height and column name with height data should be adjustable in the GUI
+        try: 
             heights = [
                 float(
                     UnitfulLength(
@@ -308,6 +305,13 @@ class SfincsAdapter:
                 for height in gdf_floodwall["z"]
             ]
             gdf_floodwall["z"] = heights
+        except Exception:
+            logging.warning(
+                f"""Could not use height data from file due to missing ""z""-column or missing values therein.\n
+                Using uniform height of {floodwall.elevation.convert(UnitTypesLength("meters"))} meters instead."""
+            )
+            gdf_floodwall["z"] = floodwall.elevation.convert(UnitTypesLength("meters"))
+            
         # par1 is the overflow coefficient for weirs
         gdf_floodwall["par1"] = 0.6
 


### PR DESCRIPTION
and also converting possible  MultiLineStrings to LineStrings to work with hydromt-sfincs

At the moment, this requires the shape file to have a z-column. Otherwise, the uniform elevation value from the GUI will be taken. I am trying to make this neater in the GUI by allowing the user to specify whether a unifrom value should be used for all floodwalls or which column should eb taken from the shape file. But I have not succeeded yet. This will be a future PR in the GUI