### PR TITLE
409 raise by datum is currently increasing the elevation above ground and not datum

### DIFF
--- a/tests/test_integrator/test_fiat_adapter.py
+++ b/tests/test_integrator/test_fiat_adapter.py
@@ -245,6 +245,17 @@ def test_fiat_raise_datum(test_db, test_tomls, exposure_template):
         )
     )
 
+    assert all(
+        height + elev
+        >= test_scenario.direct_impacts.impact_strategy.measures[
+            0
+        ].attrs.elevation.value
+        for height, elev in zip(
+            exposure_scenario.loc[inds2, "Ground Floor Height"],
+            exposure_scenario.loc[inds2, "Ground Elevation"],
+        )
+    )
+
 
 def test_fiat_return_periods(test_tomls):
     test_toml = test_tomls["current_test_set_no_measures.toml"]


### PR DESCRIPTION
issue resolved in HydroMT-FIAT (https://github.com/Deltares/hydromt_fiat/pull/302). Updated the unit-test in FloodAdapt with respect to this.