### PR TITLE
total area of all polygons from imported file

### DIFF
--- a/flood_adapt/object_model/hazard/measure/green_infrastructure.py
+++ b/flood_adapt/object_model/hazard/measure/green_infrastructure.py
@@ -105,8 +105,8 @@ class GreenInfrastructure(HazardMeasure, IGreenInfrastructure):
         crs = pyproj.CRS.from_string(site.sfincs.csname)
         gdf = gdf.to_crs(crs)
 
-        # The GeoJSON file contains only one polygon:
-        polygon = gdf.geometry.iloc[0]
-        # Calculate the area of the polygon
-        area = polygon.area
+        # The GeoJSON file can contain multiple polygons
+        polygon = gdf.geometry
+        # Calculate the area of all polygons
+        area = polygon.area.sum()
         return area


### PR DESCRIPTION
This contains a small fix to calculate the area of all polygons. The current code assumed that the geojson contains only one polygon. But this is only the case when the polygon is drawn inside the user interface, not when it is imported from a shape file.