### PR TITLE
Fix naming issues

### DIFF
--- a/flood_adapt/api/events.py
+++ b/flood_adapt/api/events.py
@@ -31,7 +31,7 @@ def get_event(name: str) -> IEvent:
 
 
 def get_event_mode(name: str) -> str:
-    filename = Database().input_path / "events" / f"{name}" / f"{name}.toml"
+    filename = Database().events.get_database_path() / f"{name}" / f"{name}.toml"
     return Event.get_mode(filename)
 
 

--- a/flood_adapt/api/output.py
+++ b/flood_adapt/api/output.py
@@ -93,7 +93,8 @@ def get_infographic(name: str) -> str:
         The HTML string of the infographic.
     """
     # Get the direct_impacts objects from the scenario
-    impact = Database().scenarios.get(name).direct_impacts
+    database = Database()
+    impact = database.scenarios.get(name).direct_impacts
 
     # Check if the scenario has run
     if not impact.has_run_check():
@@ -101,11 +102,9 @@ def get_infographic(name: str) -> str:
             f"Scenario {name} has not been run. Please run the scenario first."
         )
 
-    database_path = Path(Database().input_path).parent
-    config_path = database_path.joinpath("static", "templates", "infographics")
-    output_path = database_path.joinpath("output", "Scenarios", impact.name)
-    metrics_outputs_path = database_path.joinpath(
-        "output", "Scenarios", impact.name, f"Infometrics_{impact.name}.csv"
+    config_path = database.static_path("templates", "infographics")
+    output_path = database.output_path("Scenarios", impact.name)
+    metrics_outputs_path = database.output_path("Scenarios", impact.name, f"Infometrics_{impact.name}.csv"
     )
 
     infographic_path = InforgraphicFactory.create_infographic_file_writer(
@@ -139,8 +138,7 @@ def get_infometrics(name: str) -> pd.DataFrame:
         If the metrics file does not exist.
     """
     # Create the infographic path
-    metrics_path = Path(Database().input_path).parent.joinpath(
-        "output",
+    metrics_path = Database().output_path.joinpath(
         "Scenarios",
         name,
         f"Infometrics_{name}.csv",

--- a/flood_adapt/api/output.py
+++ b/flood_adapt/api/output.py
@@ -68,7 +68,7 @@ def get_obs_point_timeseries(name: str) -> gpd.GeoDataFrame:
         )
 
     output_path = Path(Database().output_path).joinpath("Scenarios", hazard.name)
-    gdf = Database().get_obs_points()
+    gdf = Database().static.get_obs_points()
     gdf["html"] = [
         str(output_path.joinpath("Flooding", f"{station}_timeseries.html"))
         for station in gdf.name
@@ -102,9 +102,9 @@ def get_infographic(name: str) -> str:
             f"Scenario {name} has not been run. Please run the scenario first."
         )
 
-    config_path = database.static_path("templates", "infographics")
-    output_path = database.output_path("Scenarios", impact.name)
-    metrics_outputs_path = database.output_path("Scenarios", impact.name, f"Infometrics_{impact.name}.csv"
+    config_path = database.static_path.joinpath("templates", "infographics")
+    output_path = database.output_path.joinpath("Scenarios", impact.name)
+    metrics_outputs_path = database.output_path.joinpath("Scenarios", impact.name, f"Infometrics_{impact.name}.csv"
     )
 
     infographic_path = InforgraphicFactory.create_infographic_file_writer(

--- a/flood_adapt/api/output.py
+++ b/flood_adapt/api/output.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Any
 
 import geopandas as gpd
@@ -67,7 +66,11 @@ def get_obs_point_timeseries(name: str) -> gpd.GeoDataFrame:
             f"Scenario {name} has not been run. Please run the scenario first."
         )
 
-    output_path = Database().scenarios.get_database_path(get_input_path=False).joinpath(hazard.name)
+    output_path = (
+        Database()
+        .scenarios.get_database_path(get_input_path=False)
+        .joinpath(hazard.name)
+    )
     gdf = Database().static.get_obs_points()
     gdf["html"] = [
         str(output_path.joinpath("Flooding", f"{station}_timeseries.html"))
@@ -103,9 +106,10 @@ def get_infographic(name: str) -> str:
         )
 
     config_path = database.static_path.joinpath("templates", "infographics")
-    output_path = database.scenarios.get_database_path(get_input_path=False).joinpath(impact.name)
-    metrics_outputs_path = output_path.joinpath(f"Infometrics_{impact.name}.csv"
+    output_path = database.scenarios.get_database_path(get_input_path=False).joinpath(
+        impact.name
     )
+    metrics_outputs_path = output_path.joinpath(f"Infometrics_{impact.name}.csv")
 
     infographic_path = InforgraphicFactory.create_infographic_file_writer(
         infographic_mode=impact.hazard.event_mode,
@@ -138,9 +142,13 @@ def get_infometrics(name: str) -> pd.DataFrame:
         If the metrics file does not exist.
     """
     # Create the infographic path
-    metrics_path = Database().scenarios.get_database_path(get_input_path=False).joinpath(
-        name,
-        f"Infometrics_{name}.csv",
+    metrics_path = (
+        Database()
+        .scenarios.get_database_path(get_input_path=False)
+        .joinpath(
+            name,
+            f"Infometrics_{name}.csv",
+        )
     )
 
     # Check if the file exists

--- a/flood_adapt/api/output.py
+++ b/flood_adapt/api/output.py
@@ -67,7 +67,7 @@ def get_obs_point_timeseries(name: str) -> gpd.GeoDataFrame:
             f"Scenario {name} has not been run. Please run the scenario first."
         )
 
-    output_path = Path(Database().output_path).joinpath("Scenarios", hazard.name)
+    output_path = Database().scenarios.get_database_path(get_input_path=False).joinpath(hazard.name)
     gdf = Database().static.get_obs_points()
     gdf["html"] = [
         str(output_path.joinpath("Flooding", f"{station}_timeseries.html"))
@@ -103,9 +103,8 @@ def get_infographic(name: str) -> str:
         )
 
     config_path = database.static_path.joinpath("templates", "infographics")
-    output_path = database.output_path.joinpath("Scenarios", impact.name)
-    metrics_outputs_path = database.output_path.joinpath(
-        "Scenarios", impact.name, f"Infometrics_{impact.name}.csv"
+    output_path = database.scenarios.get_database_path(get_input_path=False).joinpath(impact.name)
+    metrics_outputs_path = output_path.joinpath(f"Infometrics_{impact.name}.csv"
     )
 
     infographic_path = InforgraphicFactory.create_infographic_file_writer(
@@ -139,8 +138,7 @@ def get_infometrics(name: str) -> pd.DataFrame:
         If the metrics file does not exist.
     """
     # Create the infographic path
-    metrics_path = Database().output_path.joinpath(
-        "Scenarios",
+    metrics_path = Database().scenarios.get_database_path(get_input_path=False).joinpath(
         name,
         f"Infometrics_{name}.csv",
     )

--- a/flood_adapt/api/output.py
+++ b/flood_adapt/api/output.py
@@ -104,7 +104,8 @@ def get_infographic(name: str) -> str:
 
     config_path = database.static_path.joinpath("templates", "infographics")
     output_path = database.output_path.joinpath("Scenarios", impact.name)
-    metrics_outputs_path = database.output_path.joinpath("Scenarios", impact.name, f"Infometrics_{impact.name}.csv"
+    metrics_outputs_path = database.output_path.joinpath(
+        "Scenarios", impact.name, f"Infometrics_{impact.name}.csv"
     )
 
     infographic_path = InforgraphicFactory.create_infographic_file_writer(

--- a/flood_adapt/dbs_classes/dbs_benefit.py
+++ b/flood_adapt/dbs_classes/dbs_benefit.py
@@ -54,7 +54,7 @@ class DbsBenefit(DbsTemplate):
         super().delete(name, toml_only=toml_only)
 
         # Delete output if edited
-        output_path = self._database.output_path / "Benefits" / name
+        output_path = self._database.benefits.get_database_path(get_input_path=False) / name
 
         if output_path.exists():
             shutil.rmtree(output_path, ignore_errors=True)
@@ -76,7 +76,7 @@ class DbsBenefit(DbsTemplate):
         super().edit(benefit)
 
         # Delete output if edited
-        output_path = self._database.output_path / "Benefits" / benefit.attrs.name
+        output_path = self._database.benefits.get_database_path(get_input_path=False) / benefit.attrs.name
 
         if output_path.exists():
             shutil.rmtree(output_path, ignore_errors=True)

--- a/flood_adapt/dbs_classes/dbs_benefit.py
+++ b/flood_adapt/dbs_classes/dbs_benefit.py
@@ -54,7 +54,9 @@ class DbsBenefit(DbsTemplate):
         super().delete(name, toml_only=toml_only)
 
         # Delete output if edited
-        output_path = self._database.benefits.get_database_path(get_input_path=False) / name
+        output_path = (
+            self._database.benefits.get_database_path(get_input_path=False) / name
+        )
 
         if output_path.exists():
             shutil.rmtree(output_path, ignore_errors=True)
@@ -76,7 +78,10 @@ class DbsBenefit(DbsTemplate):
         super().edit(benefit)
 
         # Delete output if edited
-        output_path = self._database.benefits.get_database_path(get_input_path=False) / benefit.attrs.name
+        output_path = (
+            self._database.benefits.get_database_path(get_input_path=False)
+            / benefit.attrs.name
+        )
 
         if output_path.exists():
             shutil.rmtree(output_path, ignore_errors=True)

--- a/flood_adapt/dbs_classes/dbs_interface.py
+++ b/flood_adapt/dbs_classes/dbs_interface.py
@@ -133,7 +133,7 @@ class AbstractDatabaseElement(ABC):
 
     @abstractmethod
     def get_database_path(self, get_input_path: bool) -> Path:
-        """Returns the path to the database.
+        """Return the path to the database.
 
         Parameters
         ----------

--- a/flood_adapt/dbs_classes/dbs_interface.py
+++ b/flood_adapt/dbs_classes/dbs_interface.py
@@ -10,7 +10,6 @@ from flood_adapt.object_model.interface.scenarios import IScenario
 from flood_adapt.object_model.interface.strategies import IStrategy
 
 ObjectModel = Union[IScenario, IEvent, IProjection, IStrategy, IMeasure, IBenefit]
-from pathlib import Path
 
 
 class AbstractDatabaseElement(ABC):
@@ -140,7 +139,7 @@ class AbstractDatabaseElement(ABC):
         ----------
         get_input_path : bool
             whether to return the input or output path
-            
+
         Returns
         -------
         Path

--- a/flood_adapt/dbs_classes/dbs_interface.py
+++ b/flood_adapt/dbs_classes/dbs_interface.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Any, Union
 
 from flood_adapt.object_model.interface.benefits import IBenefit
@@ -127,5 +128,16 @@ class AbstractDatabaseElement(ABC):
         -------
         list[str]
             list of higher level objects that use the object
+        """
+        pass
+
+    @abstractmethod
+    def get_database_path(self) -> Path:
+        """Returns the path to the database.
+
+        Returns
+        -------
+        Path
+            path to the database
         """
         pass

--- a/flood_adapt/dbs_classes/dbs_interface.py
+++ b/flood_adapt/dbs_classes/dbs_interface.py
@@ -10,6 +10,7 @@ from flood_adapt.object_model.interface.scenarios import IScenario
 from flood_adapt.object_model.interface.strategies import IStrategy
 
 ObjectModel = Union[IScenario, IEvent, IProjection, IStrategy, IMeasure, IBenefit]
+from pathlib import Path
 
 
 class AbstractDatabaseElement(ABC):
@@ -132,9 +133,14 @@ class AbstractDatabaseElement(ABC):
         pass
 
     @abstractmethod
-    def get_database_path(self) -> Path:
+    def get_database_path(self, get_input_path: bool) -> Path:
         """Returns the path to the database.
 
+        Parameters
+        ----------
+        get_input_path : bool
+            whether to return the input or output path
+            
         Returns
         -------
         Path

--- a/flood_adapt/dbs_classes/dbs_measure.py
+++ b/flood_adapt/dbs_classes/dbs_measure.py
@@ -41,7 +41,6 @@ class DbsMeasure(DbsTemplate):
         """
         measures = self._get_object_list()
         objects = [MeasureFactory.get_measure_object(path) for path in measures["path"]]
-        measures["name"] = [obj.attrs.name for obj in objects]
         measures["description"] = [obj.attrs.description for obj in objects]
         measures["objects"] = objects
 

--- a/flood_adapt/dbs_classes/dbs_projection.py
+++ b/flood_adapt/dbs_classes/dbs_projection.py
@@ -1,6 +1,5 @@
 from flood_adapt.dbs_classes.dbs_template import DbsTemplate
 from flood_adapt.object_model.projection import Projection
-from flood_adapt.object_model.scenario import Scenario
 
 
 class DbsProjection(DbsTemplate):
@@ -43,8 +42,8 @@ class DbsProjection(DbsTemplate):
         """
         # Get all the scenarios
         scenarios = [
-            Scenario.load_file(path)
-            for path in self._database.scenarios.list_objects()["path"]
+            self._database.scenarios.get(name)
+            for name in self._database.scenarios.list_objects()["name"]
         ]
 
         # Check if projection is used in a scenario

--- a/flood_adapt/dbs_classes/dbs_scenario.py
+++ b/flood_adapt/dbs_classes/dbs_scenario.py
@@ -66,7 +66,7 @@ class DbsScenario(DbsTemplate):
         super().delete(name, toml_only)
 
         # Then delete the results
-        results_path = self._database.output_path / "Scenarios" / name
+        results_path = self._database.output_path / self._folder_name / name
         if results_path.exists():
             shutil.rmtree(results_path, ignore_errors=False)
 
@@ -88,7 +88,7 @@ class DbsScenario(DbsTemplate):
         super().edit(scenario)
 
         # Delete output if edited
-        output_path = self._database.output_path / "Scenarios" / scenario.attrs.name
+        output_path = self._database.output_path / self._folder_name / scenario.attrs.name
 
         if output_path.exists():
             shutil.rmtree(output_path, ignore_errors=True)

--- a/flood_adapt/dbs_classes/dbs_scenario.py
+++ b/flood_adapt/dbs_classes/dbs_scenario.py
@@ -88,7 +88,9 @@ class DbsScenario(DbsTemplate):
         super().edit(scenario)
 
         # Delete output if edited
-        output_path = self._database.output_path / self._folder_name / scenario.attrs.name
+        output_path = (
+            self._database.output_path / self._folder_name / scenario.attrs.name
+        )
 
         if output_path.exists():
             shutil.rmtree(output_path, ignore_errors=True)

--- a/flood_adapt/dbs_classes/dbs_strategy.py
+++ b/flood_adapt/dbs_classes/dbs_strategy.py
@@ -1,5 +1,4 @@
 from flood_adapt.dbs_classes.dbs_template import DbsTemplate
-from flood_adapt.object_model.scenario import Scenario
 from flood_adapt.object_model.strategy import Strategy
 
 
@@ -43,8 +42,8 @@ class DbsStrategy(DbsTemplate):
         """
         # Get all the scenarios
         scenarios = [
-            Scenario.load_file(path)
-            for path in self._database.scenarios.list_objects()["path"]
+            self._database.scenarios.get(name)
+            for name in self._database.scenarios.list_objects()["name"]
         ]
 
         # Check if strategy is used in a scenario

--- a/flood_adapt/dbs_classes/dbs_template.py
+++ b/flood_adapt/dbs_classes/dbs_template.py
@@ -247,6 +247,16 @@ class DbsTemplate(AbstractDatabaseElement):
         # level object. By default, return an empty list
         return []
 
+    def get_database_path(self) -> Path:
+        """Returns the path to the database.
+
+        Returns
+        -------
+        Path
+            path to the database
+        """
+        return Path(self._path)
+
     def _get_object_list(self) -> dict[Path, datetime]:
         """Get a dictionary with all the toml paths and last modification dates that exist in the database of the given object_type.
 

--- a/flood_adapt/dbs_classes/dbs_template.py
+++ b/flood_adapt/dbs_classes/dbs_template.py
@@ -258,11 +258,13 @@ class DbsTemplate(AbstractDatabaseElement):
         base_path = self.input_path / self._folder_name
         directories = list(base_path.iterdir())
         paths = [Path(dir / f"{dir.name}.toml") for dir in directories]
+        names = [dir.name for dir in directories]
         last_modification_date = [
             datetime.fromtimestamp(file.stat().st_mtime) for file in paths
         ]
 
         objects = {
+            "name": names,
             "path": paths,
             "last_modification_date": last_modification_date,
         }

--- a/flood_adapt/dbs_classes/dbs_template.py
+++ b/flood_adapt/dbs_classes/dbs_template.py
@@ -247,15 +247,23 @@ class DbsTemplate(AbstractDatabaseElement):
         # level object. By default, return an empty list
         return []
 
-    def get_database_path(self) -> Path:
+    def get_database_path(self, get_input_path: bool = True) -> Path:
         """Returns the path to the database.
+
+        Parameters
+        ----------
+        get_input_path : bool
+            whether to return the input path or the output path
 
         Returns
         -------
         Path
             path to the database
         """
-        return Path(self._path)
+        if get_input_path:
+            return Path(self._path)
+        else:
+            return Path(self._database.output_path / self._folder_name)
 
     def _get_object_list(self) -> dict[Path, datetime]:
         """Get a dictionary with all the toml paths and last modification dates that exist in the database of the given object_type.

--- a/flood_adapt/dbs_classes/dbs_template.py
+++ b/flood_adapt/dbs_classes/dbs_template.py
@@ -248,7 +248,7 @@ class DbsTemplate(AbstractDatabaseElement):
         return []
 
     def get_database_path(self, get_input_path: bool = True) -> Path:
-        """Returns the path to the database.
+        """Return the path to the database.
 
         Parameters
         ----------

--- a/flood_adapt/dbs_controller.py
+++ b/flood_adapt/dbs_controller.py
@@ -915,8 +915,7 @@ class Database(IDatabase):
         """
         # If single event read with hydromt-sfincs
         if not return_period:
-            map_path = self.output_path.joinpath(
-                "Scenarios",
+            map_path = self.scenarios.get_database_path(get_input_path = False).joinpath(
                 scenario_name,
                 "Flooding",
                 "max_water_level_map.nc",
@@ -926,8 +925,7 @@ class Database(IDatabase):
             zsmax = map.to_numpy()
 
         else:
-            file_path = self.output_path.joinpath(
-                "Scenarios",
+            file_path = self.scenarios.get_database_path(get_input_path = False).joinpath(
                 scenario_name,
                 "Flooding",
                 f"RP_{return_period:04d}_maps.nc",
@@ -948,7 +946,7 @@ class Database(IDatabase):
         GeoDataFrame
             impacts at footprint level
         """
-        out_path = self.output_path.joinpath("Scenarios", scenario_name, "Impacts")
+        out_path = self.scenarios.get_database_path(get_input_path = False).joinpath(scenario_name, "Impacts")
         footprints = out_path / f"Impacts_building_footprints_{scenario_name}.gpkg"
         gdf = gpd.read_file(footprints, engine="pyogrio")
         gdf = gdf.to_crs(4326)
@@ -967,7 +965,7 @@ class Database(IDatabase):
         GeoDataFrame
             Impacts at roads
         """
-        out_path = self.output_path.joinpath("Scenarios", scenario_name, "Impacts")
+        out_path = self.scenarios.get_database_path(get_input_path = False).joinpath(scenario_name, "Impacts")
         roads = out_path / f"Impacts_roads_{scenario_name}.gpkg"
         gdf = gpd.read_file(roads, engine="pyogrio")
         gdf = gdf.to_crs(4326)
@@ -986,7 +984,7 @@ class Database(IDatabase):
         dict[GeoDataFrame]
             dictionary with aggregated damages per aggregation type
         """
-        out_path = self.output_path.joinpath("Scenarios", scenario_name, "Impacts")
+        out_path = self.scenarios.get_database_path(get_input_path = False).joinpath(scenario_name, "Impacts")
         gdfs = {}
         for aggr_area in out_path.glob(f"Impacts_aggregated_{scenario_name}_*.gpkg"):
             label = aggr_area.stem.split(f"{scenario_name}_")[-1]
@@ -1007,8 +1005,7 @@ class Database(IDatabase):
         dict[GeoDataFrame]
             dictionary with aggregated benefits per aggregation type
         """
-        out_path = self.output_path.joinpath(
-            "Benefits",
+        out_path = self.benefits.get_database_path(get_input_path = False).joinpath(
             benefit_name,
         )
         gdfs = {}

--- a/flood_adapt/dbs_controller.py
+++ b/flood_adapt/dbs_controller.py
@@ -594,7 +594,7 @@ class Database(IDatabase):
         str
     ):  # I think we need a separate function for the different timeseries when we also want to plot multiple rivers
         temp_event = EventFactory.get_event(event["template"]).load_dict(event)
-        event_dir = self.input_path.joinpath("events", temp_event.attrs.name)
+        event_dir = self.events.get_database_path().joinpath(temp_event.attrs.name)
         temp_event.add_dis_ts(event_dir, self.site.attrs.river, input_river_df)
         river_descriptions = [i.description for i in self.site.attrs.river]
         river_names = [i.description for i in self.site.attrs.river]
@@ -769,14 +769,13 @@ class Database(IDatabase):
 
     def write_to_csv(self, name: str, event: IEvent, df: pd.DataFrame):
         df.to_csv(
-            Path(self.input_path, "events", event.attrs.name, f"{name}.csv"),
+            self.events.get_database_path().joinpath(event.attrs.name, f"{name}.csv"),
             header=False,
         )
 
     def write_cyc(self, event: IEvent, track: TropicalCyclone):
         cyc_file = (
-            self.input_path
-            / "events"
+            self.events.get_database_path()
             / event.attrs.name
             / f"{event.attrs.track_name}.cyc"
         )
@@ -916,8 +915,7 @@ class Database(IDatabase):
         """
         # If single event read with hydromt-sfincs
         if not return_period:
-            map_path = self.input_path.parent.joinpath(
-                "output",
+            map_path = self.output_path.joinpath(
                 "Scenarios",
                 scenario_name,
                 "Flooding",
@@ -928,8 +926,7 @@ class Database(IDatabase):
             zsmax = map.to_numpy()
 
         else:
-            file_path = self.input_path.parent.joinpath(
-                "output",
+            file_path = self.output_path.joinpath(
                 "Scenarios",
                 scenario_name,
                 "Flooding",
@@ -951,8 +948,7 @@ class Database(IDatabase):
         GeoDataFrame
             impacts at footprint level
         """
-        out_path = self.input_path.parent.joinpath(
-            "output", "Scenarios", scenario_name, "Impacts"
+        out_path = self.output_path.joinpath( "Scenarios", scenario_name, "Impacts"
         )
         footprints = out_path / f"Impacts_building_footprints_{scenario_name}.gpkg"
         gdf = gpd.read_file(footprints, engine="pyogrio")
@@ -972,8 +968,7 @@ class Database(IDatabase):
         GeoDataFrame
             Impacts at roads
         """
-        out_path = self.input_path.parent.joinpath(
-            "output", "Scenarios", scenario_name, "Impacts"
+        out_path = self.output_path.joinpath( "Scenarios", scenario_name, "Impacts"
         )
         roads = out_path / f"Impacts_roads_{scenario_name}.gpkg"
         gdf = gpd.read_file(roads, engine="pyogrio")
@@ -993,8 +988,7 @@ class Database(IDatabase):
         dict[GeoDataFrame]
             dictionary with aggregated damages per aggregation type
         """
-        out_path = self.input_path.parent.joinpath(
-            "output", "Scenarios", scenario_name, "Impacts"
+        out_path = self.output_path.joinpath( "Scenarios", scenario_name, "Impacts"
         )
         gdfs = {}
         for aggr_area in out_path.glob(f"Impacts_aggregated_{scenario_name}_*.gpkg"):
@@ -1016,8 +1010,7 @@ class Database(IDatabase):
         dict[GeoDataFrame]
             dictionary with aggregated benefits per aggregation type
         """
-        out_path = self.input_path.parent.joinpath(
-            "output",
+        out_path = self.output_path.joinpath(
             "Benefits",
             benefit_name,
         )
@@ -1076,11 +1069,9 @@ class Database(IDatabase):
 
         for scn in scns_simulated:
             if scn.direct_impacts.hazard == scenario.direct_impacts.hazard:
-                path_0 = self.input_path.parent.joinpath(
-                    "output", "Scenarios", scn.attrs.name, "Flooding"
+                path_0 = self.output_path.joinpath( "Scenarios", scn.attrs.name, "Flooding"
                 )
-                path_new = self.input_path.parent.joinpath(
-                    "output", "Scenarios", scenario.attrs.name, "Flooding"
+                path_new = self.output_path.joinpath( "Scenarios", scenario.attrs.name, "Flooding"
                 )
                 if (
                     scn.direct_impacts.hazard.has_run_check()

--- a/flood_adapt/dbs_controller.py
+++ b/flood_adapt/dbs_controller.py
@@ -47,6 +47,7 @@ class Database(IDatabase):
     database_name: str
     _init_done: bool = False
 
+    base_path: Path
     input_path: Path
     static_path: Path
     output_path: Path
@@ -106,9 +107,11 @@ class Database(IDatabase):
         self.database_path = database_path
         self.database_name = database_name
 
-        self.input_path = Path(database_path / database_name / "input")
-        self.static_path = Path(database_path / database_name / "static")
-        self.output_path = Path(database_path / database_name / "output")
+        # Set the paths
+        self.base_path = Path(database_path / database_name)
+        self.input_path = self.base_path / "Input"
+        self.static_path = self.base_path / "Static"
+        self.output_path = self.base_path / "Output"
 
         self._site = Site.load_file(self.static_path / "site" / "site.toml")
 

--- a/flood_adapt/dbs_controller.py
+++ b/flood_adapt/dbs_controller.py
@@ -948,8 +948,7 @@ class Database(IDatabase):
         GeoDataFrame
             impacts at footprint level
         """
-        out_path = self.output_path.joinpath( "Scenarios", scenario_name, "Impacts"
-        )
+        out_path = self.output_path.joinpath("Scenarios", scenario_name, "Impacts")
         footprints = out_path / f"Impacts_building_footprints_{scenario_name}.gpkg"
         gdf = gpd.read_file(footprints, engine="pyogrio")
         gdf = gdf.to_crs(4326)
@@ -968,8 +967,7 @@ class Database(IDatabase):
         GeoDataFrame
             Impacts at roads
         """
-        out_path = self.output_path.joinpath( "Scenarios", scenario_name, "Impacts"
-        )
+        out_path = self.output_path.joinpath("Scenarios", scenario_name, "Impacts")
         roads = out_path / f"Impacts_roads_{scenario_name}.gpkg"
         gdf = gpd.read_file(roads, engine="pyogrio")
         gdf = gdf.to_crs(4326)
@@ -988,8 +986,7 @@ class Database(IDatabase):
         dict[GeoDataFrame]
             dictionary with aggregated damages per aggregation type
         """
-        out_path = self.output_path.joinpath( "Scenarios", scenario_name, "Impacts"
-        )
+        out_path = self.output_path.joinpath("Scenarios", scenario_name, "Impacts")
         gdfs = {}
         for aggr_area in out_path.glob(f"Impacts_aggregated_{scenario_name}_*.gpkg"):
             label = aggr_area.stem.split(f"{scenario_name}_")[-1]
@@ -1069,9 +1066,11 @@ class Database(IDatabase):
 
         for scn in scns_simulated:
             if scn.direct_impacts.hazard == scenario.direct_impacts.hazard:
-                path_0 = self.output_path.joinpath( "Scenarios", scn.attrs.name, "Flooding"
+                path_0 = self.output_path.joinpath(
+                    "Scenarios", scn.attrs.name, "Flooding"
                 )
-                path_new = self.output_path.joinpath( "Scenarios", scenario.attrs.name, "Flooding"
+                path_new = self.output_path.joinpath(
+                    "Scenarios", scenario.attrs.name, "Flooding"
                 )
                 if (
                     scn.direct_impacts.hazard.has_run_check()

--- a/flood_adapt/dbs_controller.py
+++ b/flood_adapt/dbs_controller.py
@@ -1063,11 +1063,9 @@ class Database(IDatabase):
 
         for scn in scns_simulated:
             if scn.direct_impacts.hazard == scenario.direct_impacts.hazard:
-                path_0 = self.output_path.joinpath(
-                    "Scenarios", scn.attrs.name, "Flooding"
+                path_0 = self.scenarios.get_database_path(get_input_path=False).joinpath(scn.attrs.name, "Flooding"
                 )
-                path_new = self.output_path.joinpath(
-                    "Scenarios", scenario.attrs.name, "Flooding"
+                path_new = self.scenarios.get_database_path(get_input_path=False).joinpath(scenario.attrs.name, "Flooding"
                 )
                 if (
                     scn.direct_impacts.hazard.has_run_check()

--- a/flood_adapt/dbs_controller.py
+++ b/flood_adapt/dbs_controller.py
@@ -109,9 +109,9 @@ class Database(IDatabase):
 
         # Set the paths
         self.base_path = Path(database_path / database_name)
-        self.input_path = self.base_path / "Input"
-        self.static_path = self.base_path / "Static"
-        self.output_path = self.base_path / "Output"
+        self.input_path = self.base_path / "input"
+        self.static_path = self.base_path / "static"
+        self.output_path = self.base_path / "output"
 
         self._site = Site.load_file(self.static_path / "site" / "site.toml")
 

--- a/flood_adapt/dbs_controller.py
+++ b/flood_adapt/dbs_controller.py
@@ -915,7 +915,7 @@ class Database(IDatabase):
         """
         # If single event read with hydromt-sfincs
         if not return_period:
-            map_path = self.scenarios.get_database_path(get_input_path = False).joinpath(
+            map_path = self.scenarios.get_database_path(get_input_path=False).joinpath(
                 scenario_name,
                 "Flooding",
                 "max_water_level_map.nc",
@@ -925,7 +925,7 @@ class Database(IDatabase):
             zsmax = map.to_numpy()
 
         else:
-            file_path = self.scenarios.get_database_path(get_input_path = False).joinpath(
+            file_path = self.scenarios.get_database_path(get_input_path=False).joinpath(
                 scenario_name,
                 "Flooding",
                 f"RP_{return_period:04d}_maps.nc",
@@ -946,7 +946,9 @@ class Database(IDatabase):
         GeoDataFrame
             impacts at footprint level
         """
-        out_path = self.scenarios.get_database_path(get_input_path = False).joinpath(scenario_name, "Impacts")
+        out_path = self.scenarios.get_database_path(get_input_path=False).joinpath(
+            scenario_name, "Impacts"
+        )
         footprints = out_path / f"Impacts_building_footprints_{scenario_name}.gpkg"
         gdf = gpd.read_file(footprints, engine="pyogrio")
         gdf = gdf.to_crs(4326)
@@ -965,7 +967,9 @@ class Database(IDatabase):
         GeoDataFrame
             Impacts at roads
         """
-        out_path = self.scenarios.get_database_path(get_input_path = False).joinpath(scenario_name, "Impacts")
+        out_path = self.scenarios.get_database_path(get_input_path=False).joinpath(
+            scenario_name, "Impacts"
+        )
         roads = out_path / f"Impacts_roads_{scenario_name}.gpkg"
         gdf = gpd.read_file(roads, engine="pyogrio")
         gdf = gdf.to_crs(4326)
@@ -984,7 +988,9 @@ class Database(IDatabase):
         dict[GeoDataFrame]
             dictionary with aggregated damages per aggregation type
         """
-        out_path = self.scenarios.get_database_path(get_input_path = False).joinpath(scenario_name, "Impacts")
+        out_path = self.scenarios.get_database_path(get_input_path=False).joinpath(
+            scenario_name, "Impacts"
+        )
         gdfs = {}
         for aggr_area in out_path.glob(f"Impacts_aggregated_{scenario_name}_*.gpkg"):
             label = aggr_area.stem.split(f"{scenario_name}_")[-1]
@@ -1005,7 +1011,7 @@ class Database(IDatabase):
         dict[GeoDataFrame]
             dictionary with aggregated benefits per aggregation type
         """
-        out_path = self.benefits.get_database_path(get_input_path = False).joinpath(
+        out_path = self.benefits.get_database_path(get_input_path=False).joinpath(
             benefit_name,
         )
         gdfs = {}
@@ -1063,10 +1069,12 @@ class Database(IDatabase):
 
         for scn in scns_simulated:
             if scn.direct_impacts.hazard == scenario.direct_impacts.hazard:
-                path_0 = self.scenarios.get_database_path(get_input_path=False).joinpath(scn.attrs.name, "Flooding"
-                )
-                path_new = self.scenarios.get_database_path(get_input_path=False).joinpath(scenario.attrs.name, "Flooding"
-                )
+                path_0 = self.scenarios.get_database_path(
+                    get_input_path=False
+                ).joinpath(scn.attrs.name, "Flooding")
+                path_new = self.scenarios.get_database_path(
+                    get_input_path=False
+                ).joinpath(scenario.attrs.name, "Flooding")
                 if (
                     scn.direct_impacts.hazard.has_run_check()
                 ):  # only copy results if the hazard model has actually finished and skip simulation folders

--- a/flood_adapt/object_model/direct_impacts.py
+++ b/flood_adapt/object_model/direct_impacts.py
@@ -45,16 +45,16 @@ class DirectImpacts:
     has_run: bool = False
 
     def __init__(
-        self, scenario: ScenarioModel, database_input_path: Path, results_path: Path
+        self, scenario: ScenarioModel, database, results_path: Path
     ) -> None:
         self.name = scenario.name
-        self.database_input_path = database_input_path
+        self.database_input_path = database.input_path
         self.scenario = scenario
         self.results_path = results_path
         self.set_socio_economic_change(scenario.projection)
         self.set_impact_strategy(scenario.strategy)
         self.set_hazard(
-            scenario, database_input_path, self.results_path.joinpath("Flooding")
+            scenario, database, self.results_path.joinpath("Flooding")
         )
         # Get site config
         self.site_toml_path = (
@@ -125,7 +125,7 @@ class DirectImpacts:
         self.impact_strategy = Strategy.load_file(strategy_path).get_impact_strategy()
 
     def set_hazard(
-        self, scenario: ScenarioModel, database_input_path: Path, results_dir: Path
+        self, scenario: ScenarioModel, database, results_dir: Path
     ) -> None:
         """Set the Hazard object of the scenario.
 
@@ -134,7 +134,7 @@ class DirectImpacts:
         scenario : str
             Name of the scenario
         """
-        self.hazard = Hazard(scenario, database_input_path, results_dir)
+        self.hazard = Hazard(scenario, database, results_dir)
 
     def preprocess_models(self):
         logging.info("Preparing impact models...")

--- a/flood_adapt/object_model/direct_impacts.py
+++ b/flood_adapt/object_model/direct_impacts.py
@@ -51,11 +51,11 @@ class DirectImpacts:
         self.set_impact_strategy(scenario.strategy)
         self.set_hazard(scenario, database, self.results_path.joinpath("Flooding"))
         # Get site config
-        self.site_toml_path = self.database.static_path / "Site" / "site.toml"
+        self.site_toml_path = self.database.static_path / "site" / "site.toml"
         self.site_info = database.site
         # Define results path
         self.impacts_path = self.results_path.joinpath("Impacts")
-        self.fiat_path = self.impacts_path.joinpath("Fiat_model")
+        self.fiat_path = self.impacts_path.joinpath("fiat_model")
         self.has_run = self.has_run_check()
 
     def has_run_check(self) -> bool:
@@ -158,7 +158,7 @@ class DirectImpacts:
             )
 
         # Get the location of the FIAT template model
-        template_path = self.database.static_path / "Templates" / "Fiat"
+        template_path = self.database.static_path / "templates" / "fiat"
 
         # Read FIAT template with FIAT adapter
         fa = FiatAdapter(
@@ -194,7 +194,7 @@ class DirectImpacts:
             )
             dem = self.database.static_path / "Dem" / self.site_info.attrs.dem.filename
             aggregation_areas = [
-                self.database.static_path / "Site" / aggr.file
+                self.database.static_path / "site" / aggr.file
                 for aggr in self.site_info.attrs.fiat.aggregation
             ]
             attribute_names = [
@@ -261,7 +261,7 @@ class DirectImpacts:
                 The path should be a directory containing folders with the model executables
                 """
             )
-        fiat_exec = FloodAdapt_config.get_system_folder() / "Fiat" / "fiat.exe"
+        fiat_exec = FloodAdapt_config.get_system_folder() / "fiat" / "fiat.exe"
 
         with cd(self.fiat_path):
             with open(self.fiat_path.joinpath("fiat.log"), "a") as log_handler:
@@ -283,7 +283,7 @@ class DirectImpacts:
         fiat_results_path = self.impacts_path.joinpath(
             f"Impacts_detailed_{self.name}.csv"
         )
-        shutil.copy(self.fiat_path.joinpath("Output", "output.csv"), fiat_results_path)
+        shutil.copy(self.fiat_path.joinpath("output", "output.csv"), fiat_results_path)
 
         # Add exceedance probability if needed (only for risk)
         if self.hazard.event_mode == "risk":
@@ -325,7 +325,7 @@ class DirectImpacts:
         logging.info("Saving road impacts...")
         # Read roads spatial file
         roads = gpd.read_file(
-            self.fiat_path.joinpath("Output", self.site_info.attrs.fiat.roads_file_name)
+            self.fiat_path.joinpath("output", self.site_info.attrs.fiat.roads_file_name)
         )
         # Get columns to use
         aggr_cols = [
@@ -492,7 +492,7 @@ class DirectImpacts:
         """
         # Get config path
         config_path = self.database.static_path.joinpath(
-            "Templates", "Infometrics", "metrics_additional_risk_configs.toml"
+            "templates", "infometrics", "metrics_additional_risk_configs.toml"
         )
         with open(config_path, mode="rb") as fp:
             config = tomli.load(fp)["flood_exceedance"]
@@ -520,15 +520,15 @@ class DirectImpacts:
             ext = ""
 
         metrics_config_path = self.database.static_path.joinpath(
-            "Templates",
-            "Infometrics",
+            "templates",
+            "infometrics",
             f"metrics_config{ext}.toml",
         )
 
         # Specify the metrics output path
         metrics_outputs_path = self.database.output_path.joinpath(
             "Scenarios",
-            self.name.capitalize(),
+            self.name,
             f"Infometrics_{self.name}.csv",
         )
 
@@ -558,9 +558,9 @@ class DirectImpacts:
             scenario_name=self.name,
             metrics_full_path=metrics_path,
             config_base_path=self.database.static_path.joinpath(
-                "Templates", "Infographics"
+                "templates", "Infographics"
             ),
             output_base_path=self.database.output_path.joinpath(
-                "Scenarios", self.name.capitalize()
+                "Scenarios", self.name
             ),
         ).write_infographics_to_file()

--- a/flood_adapt/object_model/direct_impacts.py
+++ b/flood_adapt/object_model/direct_impacts.py
@@ -524,7 +524,9 @@ class DirectImpacts:
         )
 
         # Specify the metrics output path
-        metrics_outputs_path = self.database.scenarios.get_database_path(get_input_path=False).joinpath(
+        metrics_outputs_path = self.database.scenarios.get_database_path(
+            get_input_path=False
+        ).joinpath(
             self.name,
             f"Infometrics_{self.name}.csv",
         )
@@ -557,5 +559,7 @@ class DirectImpacts:
             config_base_path=self.database.static_path.joinpath(
                 "templates", "Infographics"
             ),
-            output_base_path=self.database.scenarios.get_database_path(get_input_path=False).joinpath(self.name),
+            output_base_path=self.database.scenarios.get_database_path(
+                get_input_path=False
+            ).joinpath(self.name),
         ).write_infographics_to_file()

--- a/flood_adapt/object_model/direct_impacts.py
+++ b/flood_adapt/object_model/direct_impacts.py
@@ -110,9 +110,7 @@ class DirectImpacts:
             strategy
         ).get_impact_strategy()
 
-    def set_hazard(
-        self, scenario: ScenarioModel, database, results_dir: Path
-    ) -> None:
+    def set_hazard(self, scenario: ScenarioModel, database, results_dir: Path) -> None:
         """Set the Hazard object of the scenario.
 
         Parameters

--- a/flood_adapt/object_model/direct_impacts.py
+++ b/flood_adapt/object_model/direct_impacts.py
@@ -557,5 +557,5 @@ class DirectImpacts:
             config_base_path=self.database.static_path.joinpath(
                 "templates", "Infographics"
             ),
-            output_base_path=self.database.output_path.joinpath("Scenarios", self.name),
+            output_base_path=self.database.scenarios.get_database_path(get_input_path=False).joinpath(self.name),
         ).write_infographics_to_file()

--- a/flood_adapt/object_model/direct_impacts.py
+++ b/flood_adapt/object_model/direct_impacts.py
@@ -524,8 +524,7 @@ class DirectImpacts:
         )
 
         # Specify the metrics output path
-        metrics_outputs_path = self.database.output_path.joinpath(
-            "Scenarios",
+        metrics_outputs_path = self.database.scenarios.get_database_path(get_input_path=False).joinpath(
             self.name,
             f"Infometrics_{self.name}.csv",
         )

--- a/flood_adapt/object_model/direct_impacts.py
+++ b/flood_adapt/object_model/direct_impacts.py
@@ -35,7 +35,6 @@ class DirectImpacts:
     """
 
     name: str
-    database_input_path: Path
     socio_economic_change: SocioEconomicChange
     impact_strategy: ImpactStrategy
     hazard: Hazard
@@ -44,7 +43,6 @@ class DirectImpacts:
     def __init__(self, scenario: ScenarioModel, database, results_path: Path) -> None:
         self.name = scenario.name
         self.database = database
-        self.database_input_path = database.input_path
         self.scenario = scenario
         self.results_path = results_path
         self.set_socio_economic_change(scenario.projection)

--- a/flood_adapt/object_model/direct_impacts.py
+++ b/flood_adapt/object_model/direct_impacts.py
@@ -558,7 +558,5 @@ class DirectImpacts:
             config_base_path=self.database.static_path.joinpath(
                 "templates", "Infographics"
             ),
-            output_base_path=self.database.output_path.joinpath(
-                "Scenarios", self.name
-            ),
+            output_base_path=self.database.output_path.joinpath("Scenarios", self.name),
         ).write_infographics_to_file()

--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -57,21 +57,19 @@ class Hazard:
     has_run: bool = False
 
     def __init__(
-        self, scenario: ScenarioModel, database_input_path: Path, results_dir: Path
+        self, scenario: ScenarioModel, database, results_dir: Path
     ) -> None:
         self._mode: Mode
         self.simulation_paths: List[Path]
         self.simulation_paths_offshore: List[Path]
         self.name = scenario.name
         self.results_dir = results_dir
-        self.database_input_path = database_input_path
+        self.database_input_path = database.input_path
         self.event_name = scenario.event
         self.set_event()  # also setting the mode (single_event or risk here)
         self.set_hazard_strategy(scenario.strategy)
         self.set_physical_projection(scenario.projection)
-        self.site = Site.load_file(
-            database_input_path.parent / "static" / "site" / "site.toml"
-        )
+        self.site = database.site
         self.has_run = self.has_run_check()
 
     @property

--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -80,20 +80,20 @@ class Hazard:
             self.simulation_paths = [
                 self.database.output_path.joinpath(
                     "Scenarios",
-                    self.name.capitalize(),
+                    self.name,
                     "Flooding",
-                    "Simulations",
-                    self.site.attrs.sfincs.overland_model.capitalize(),
+                    "simulations",
+                    self.site.attrs.sfincs.overland_model,
                 )
             ]
             # Create a folder name for the offshore model (will not be used if offshore model is not created)
             self.simulation_paths_offshore = [
                 self.database.output_path.joinpath(
                     "Scenarios",
-                    self.name.capitalize(),
+                    self.name,
                     "Flooding",
                     "simulations",
-                    self.site.attrs.sfincs.offshore_model.capitalize(),
+                    self.site.attrs.sfincs.offshore_model,
                 )
             ]
         elif self._mode == Mode.risk:  # risk mode requires an additional folder layer
@@ -103,22 +103,22 @@ class Hazard:
                 self.simulation_paths.append(
                     self.database.output_path.joinpath(
                         "Scenarios",
-                        self.name.capitalize(),
+                        self.name,
                         "Flooding",
-                        "Simulations",
-                        subevent.attrs.name.capitalize(),
-                        self.site.attrs.sfincs.overland_model.capitalize(),
+                        "simulations",
+                        subevent.attrs.name,
+                        self.site.attrs.sfincs.overland_model,
                     )
                 )
                 # Create a folder name for the offshore model (will not be used if offshore model is not created)
                 self.simulation_paths_offshore.append(
                     self.database.output_path.joinpath(
                         "Scenarios",
-                        self.name.capitalize(),
+                        self.name,
                         "Flooding",
-                        "Simulations",
-                        subevent.attrs.name.capitalize(),
-                        self.site.attrs.sfincs.offshore_model.capitalize(),
+                        "simulations",
+                        subevent.attrs.name,
+                        self.site.attrs.sfincs.offshore_model,
                     )
                 )
 
@@ -172,7 +172,7 @@ class Hazard:
         """
         self.event_set_path = (
             self.database.events.get_database_path()
-            / self.event_name.capitalize()
+            / self.event_name
             / f"{self.event_name}.toml"
         )
         # set mode (probabilistic_set or single_event)
@@ -191,8 +191,8 @@ class Hazard:
             for subevent in subevents:
                 event_path = (
                     self.database.events.get_database_path()
-                    / self.event_name.capitalize()
-                    / subevent.capitalize()
+                    / self.event_name
+                    / subevent
                     / f"{subevent}.toml"
                 )
                 self.event_set.event_paths.append(event_path)
@@ -244,7 +244,7 @@ class Hazard:
         # add other models here
         # remove simulation folders
         if not self.site.attrs.sfincs.save_simulation:
-            sim_path = self.results_dir.joinpath("Simulations")
+            sim_path = self.results_dir.joinpath("simulations")
             if os.path.exists(sim_path):
                 try:
                     shutil.rmtree(sim_path)
@@ -261,7 +261,7 @@ class Hazard:
                 """
             )
 
-        sfincs_exec = FloodAdapt_config.get_system_folder() / "Sfincs" / "sfincs.exe"
+        sfincs_exec = FloodAdapt_config.get_system_folder() / "sfincs" / "sfincs.exe"
 
         run_success = True
         for simulation_path in self.simulation_paths:
@@ -302,7 +302,7 @@ class Hazard:
                 The path should be a directory containing folders with the model executables
                 """
             )
-        sfincs_exec = FloodAdapt_config.get_system_folder() / "Sfincs" / "sfincs.exe"
+        sfincs_exec = FloodAdapt_config.get_system_folder() / "sfincs" / "sfincs.exe"
 
         simulation_path = self.simulation_paths_offshore[ii]
         with cd(simulation_path):
@@ -316,7 +316,7 @@ class Hazard:
         self._set_event_objects()
         self.set_simulation_paths()
         path_in = self.database.static_path.joinpath(
-            "Templates", self.site.attrs.sfincs.overland_model.capitalize()
+            "templates", self.site.attrs.sfincs.overland_model
         )
 
         for ii, event in enumerate(self.event_list):
@@ -594,7 +594,7 @@ class Hazard:
         """
         # Determine folders for offshore model
         path_in_offshore = self.database.static_path.joinpath(
-            "Templates", self.site.attrs.sfincs.offshore_model
+            "templates", self.site.attrs.sfincs.offshore_model
         )
         if self.event_mode == Mode.risk:
             event_dir = (

--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -78,7 +78,9 @@ class Hazard:
     def set_simulation_paths(self) -> None:
         if self._mode == Mode.single_event:
             self.simulation_paths = [
-                self.database.scenarios.get_database_path(get_input_path=False).joinpath(
+                self.database.scenarios.get_database_path(
+                    get_input_path=False
+                ).joinpath(
                     self.name,
                     "Flooding",
                     "simulations",
@@ -87,7 +89,9 @@ class Hazard:
             ]
             # Create a folder name for the offshore model (will not be used if offshore model is not created)
             self.simulation_paths_offshore = [
-                self.database.scenarios.get_database_path(get_input_path=False).joinpath(
+                self.database.scenarios.get_database_path(
+                    get_input_path=False
+                ).joinpath(
                     self.name,
                     "Flooding",
                     "simulations",
@@ -99,7 +103,9 @@ class Hazard:
             self.simulation_paths_offshore = []
             for subevent in self.event_list:
                 self.simulation_paths.append(
-                    self.database.scenarios.get_database_path(get_input_path=False).joinpath(
+                    self.database.scenarios.get_database_path(
+                        get_input_path=False
+                    ).joinpath(
                         self.name,
                         "Flooding",
                         "simulations",
@@ -109,7 +115,9 @@ class Hazard:
                 )
                 # Create a folder name for the offshore model (will not be used if offshore model is not created)
                 self.simulation_paths_offshore.append(
-                    self.database.scenarios.get_database_path(get_input_path=False).joinpath(
+                    self.database.scenarios.get_database_path(
+                        get_input_path=False
+                    ).joinpath(
                         self.name,
                         "Flooding",
                         "simulations",

--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -78,8 +78,7 @@ class Hazard:
     def set_simulation_paths(self) -> None:
         if self._mode == Mode.single_event:
             self.simulation_paths = [
-                self.database.output_path.joinpath(
-                    "Scenarios",
+                self.database.scenarios.get_database_path(get_input_path=False).joinpath(
                     self.name,
                     "Flooding",
                     "simulations",
@@ -88,8 +87,7 @@ class Hazard:
             ]
             # Create a folder name for the offshore model (will not be used if offshore model is not created)
             self.simulation_paths_offshore = [
-                self.database.output_path.joinpath(
-                    "Scenarios",
+                self.database.scenarios.get_database_path(get_input_path=False).joinpath(
                     self.name,
                     "Flooding",
                     "simulations",
@@ -101,8 +99,7 @@ class Hazard:
             self.simulation_paths_offshore = []
             for subevent in self.event_list:
                 self.simulation_paths.append(
-                    self.database.output_path.joinpath(
-                        "Scenarios",
+                    self.database.scenarios.get_database_path(get_input_path=False).joinpath(
                         self.name,
                         "Flooding",
                         "simulations",
@@ -112,8 +109,7 @@ class Hazard:
                 )
                 # Create a folder name for the offshore model (will not be used if offshore model is not created)
                 self.simulation_paths_offshore.append(
-                    self.database.output_path.joinpath(
-                        "Scenarios",
+                    self.database.scenarios.get_database_path(get_input_path=False).joinpath(
                         self.name,
                         "Flooding",
                         "simulations",

--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -35,9 +35,6 @@ from flood_adapt.object_model.io.unitfulvalue import (
     UnitTypesLength,
     UnitTypesVelocity,
 )
-from flood_adapt.object_model.projection import Projection
-from flood_adapt.object_model.site import Site
-from flood_adapt.object_model.strategy import Strategy
 from flood_adapt.object_model.utils import cd
 
 
@@ -56,15 +53,13 @@ class Hazard:
     hazard_strategy: HazardStrategy
     has_run: bool = False
 
-    def __init__(
-        self, scenario: ScenarioModel, database, results_dir: Path
-    ) -> None:
+    def __init__(self, scenario: ScenarioModel, database, results_dir: Path) -> None:
         self._mode: Mode
         self.simulation_paths: List[Path]
         self.simulation_paths_offshore: List[Path]
         self.name = scenario.name
         self.results_dir = results_dir
-        self.database_input_path = database.input_path
+        self.database = database
         self.event_name = scenario.event
         self.set_event()  # also setting the mode (single_event or risk here)
         self.set_hazard_strategy(scenario.strategy)
@@ -83,24 +78,22 @@ class Hazard:
     def set_simulation_paths(self) -> None:
         if self._mode == Mode.single_event:
             self.simulation_paths = [
-                self.database_input_path.parent.joinpath(
-                    "output",
+                self.database.output_path.joinpath(
                     "Scenarios",
-                    self.name,
+                    self.name.capitalize(),
                     "Flooding",
-                    "simulations",
-                    self.site.attrs.sfincs.overland_model,
+                    "Simulations",
+                    self.site.attrs.sfincs.overland_model.capitalize(),
                 )
             ]
             # Create a folder name for the offshore model (will not be used if offshore model is not created)
             self.simulation_paths_offshore = [
-                self.database_input_path.parent.joinpath(
-                    "output",
+                self.database.output_path.joinpath(
                     "Scenarios",
-                    self.name,
+                    self.name.capitalize(),
                     "Flooding",
                     "simulations",
-                    self.site.attrs.sfincs.offshore_model,
+                    self.site.attrs.sfincs.offshore_model.capitalize(),
                 )
             ]
         elif self._mode == Mode.risk:  # risk mode requires an additional folder layer
@@ -108,26 +101,24 @@ class Hazard:
             self.simulation_paths_offshore = []
             for subevent in self.event_list:
                 self.simulation_paths.append(
-                    self.database_input_path.parent.joinpath(
-                        "output",
+                    self.database.output_path.joinpath(
                         "Scenarios",
-                        self.name,
+                        self.name.capitalize(),
                         "Flooding",
-                        "simulations",
-                        subevent.attrs.name,
-                        self.site.attrs.sfincs.overland_model,
+                        "Simulations",
+                        subevent.attrs.name.capitalize(),
+                        self.site.attrs.sfincs.overland_model.capitalize(),
                     )
                 )
                 # Create a folder name for the offshore model (will not be used if offshore model is not created)
                 self.simulation_paths_offshore.append(
-                    self.database_input_path.parent.joinpath(
-                        "output",
+                    self.database.output_path.joinpath(
                         "Scenarios",
-                        self.name,
+                        self.name.capitalize(),
                         "Flooding",
-                        "simulations",
-                        subevent.attrs.name,
-                        self.site.attrs.sfincs.offshore_model,
+                        "Simulations",
+                        subevent.attrs.name.capitalize(),
+                        self.site.attrs.sfincs.offshore_model.capitalize(),
                     )
                 )
 
@@ -180,10 +171,9 @@ class Hazard:
             event_name (str): name of event used in scenario.
         """
         self.event_set_path = (
-            self.database_input_path
-            / "events"
-            / self.event_name
-            / "{}.toml".format(self.event_name)
+            self.database.events.get_database_path()
+            / self.event_name.capitalize()
+            / f"{self.event_name}.toml"
         )
         # set mode (probabilistic_set or single_event)
         self.event_mode = Event.get_mode(self.event_set_path)
@@ -200,11 +190,10 @@ class Hazard:
 
             for subevent in subevents:
                 event_path = (
-                    self.database_input_path
-                    / "events"
-                    / self.event_name
-                    / subevent
-                    / "{}.toml".format(subevent)
+                    self.database.events.get_database_path()
+                    / self.event_name.capitalize()
+                    / subevent.capitalize()
+                    / f"{subevent}.toml"
                 )
                 self.event_set.event_paths.append(event_path)
 
@@ -221,31 +210,16 @@ class Hazard:
             ]  # set event for single_event to be able to plot wl etc
 
     def set_physical_projection(self, projection: str) -> None:
-        projection_path = (
-            self.database_input_path / "Projections" / projection / f"{projection}.toml"
-        )
-        self.physical_projection = Projection.load_file(
-            projection_path
+        self.physical_projection = self.database.projections.get(
+            projection
         ).get_physical_projection()
 
     def set_hazard_strategy(self, strategy: str) -> None:
-        strategy_path = (
-            self.database_input_path / "Strategies" / strategy / f"{strategy}.toml"
-        )
-        self.hazard_strategy = Strategy.load_file(strategy_path).get_hazard_strategy()
+        self.hazard_strategy = self.database.strategies.get(
+            strategy
+        ).get_hazard_strategy()
 
     # no write function is needed since this is only used internally
-
-    @staticmethod
-    def get_event_object(event_path):
-        mode = Event.get_mode(event_path)
-        if mode == Mode.single_event:
-            # parse event config file to get event template
-            template = Event.get_template(event_path)
-            # use event template to get the associated event child class
-            return EventFactory.get_event(template).load_file(event_path)
-        elif mode == Mode.risk:
-            return EventSet.load_file(event_path)
 
     def preprocess_models(self):
         logging.info("Preparing hazard models...")
@@ -270,7 +244,7 @@ class Hazard:
         # add other models here
         # remove simulation folders
         if not self.site.attrs.sfincs.save_simulation:
-            sim_path = self.results_dir.joinpath("simulations")
+            sim_path = self.results_dir.joinpath("Simulations")
             if os.path.exists(sim_path):
                 try:
                     shutil.rmtree(sim_path)
@@ -287,7 +261,7 @@ class Hazard:
                 """
             )
 
-        sfincs_exec = FloodAdapt_config.get_system_folder() / "sfincs" / "sfincs.exe"
+        sfincs_exec = FloodAdapt_config.get_system_folder() / "Sfincs" / "sfincs.exe"
 
         run_success = True
         for simulation_path in self.simulation_paths:
@@ -328,7 +302,7 @@ class Hazard:
                 The path should be a directory containing folders with the model executables
                 """
             )
-        sfincs_exec = FloodAdapt_config.get_system_folder() / "sfincs" / "sfincs.exe"
+        sfincs_exec = FloodAdapt_config.get_system_folder() / "Sfincs" / "sfincs.exe"
 
         simulation_path = self.simulation_paths_offshore[ii]
         with cd(simulation_path):
@@ -341,9 +315,8 @@ class Hazard:
     ):
         self._set_event_objects()
         self.set_simulation_paths()
-        base_path = self.database_input_path.parent
-        path_in = base_path.joinpath(
-            "static", "templates", self.site.attrs.sfincs.overland_model
+        path_in = self.database.static_path.joinpath(
+            "Templates", self.site.attrs.sfincs.overland_model.capitalize()
         )
 
         for ii, event in enumerate(self.event_list):
@@ -367,11 +340,9 @@ class Hazard:
                 or self.event.attrs.template == "Historical_offshore"
             ):
                 logging.info("Downloading meteo data...")
-                meteo_dir = self.database_input_path.parent.joinpath("output", "meteo")
+                meteo_dir = self.database.output_path.joinpath("meteo")
                 if not meteo_dir.is_dir():
-                    os.mkdir(
-                        self.database_input_path.parent.joinpath("output", "meteo")
-                    )
+                    os.mkdir(self.database.output_path.joinpath("meteo"))
                 ds = self.event.download_meteo(
                     site=self.site, path=meteo_dir
                 )  # =event_dir)
@@ -507,8 +478,8 @@ class Hazard:
                         "Adding rainfall shape timeseries to the overland flood model..."
                     )
                     if self.event.attrs.rainfall.shape_type == "scs":
-                        scsfile = self.database_input_path.parent.joinpath(
-                            "static", "scs", self.site.attrs.scs.file
+                        scsfile = self.database.static_path.joinpath(
+                            "scs", self.site.attrs.scs.file
                         )
                         scstype = self.site.attrs.scs.type
                         self.event.add_rainfall_ts(scsfile=scsfile, scstype=scstype)
@@ -575,8 +546,8 @@ class Hazard:
             # Add hazard measures if included
             if self.hazard_strategy.measures is not None:
                 for measure in self.hazard_strategy.measures:
-                    measure_path = base_path.joinpath(
-                        "input", "measures", measure.attrs.name
+                    measure_path = self.database.measures.get_database_path().joinpath(
+                        measure.attrs.name
                     )
                     if measure.attrs.type == "floodwall":
                         logging.info("Adding floodwall to the overland flood model...")
@@ -622,19 +593,17 @@ class Hazard:
             ii (int): Iterator for event set
         """
         # Determine folders for offshore model
-        base_path = self.database_input_path.parent
-        path_in_offshore = base_path.joinpath(
-            "static", "templates", self.site.attrs.sfincs.offshore_model
+        path_in_offshore = self.database.static_path.joinpath(
+            "Templates", self.site.attrs.sfincs.offshore_model
         )
         if self.event_mode == Mode.risk:
             event_dir = (
-                self.database_input_path
-                / "events"
+                self.database.events.get_database_path()
                 / self.event_set.attrs.name
                 / self.event.attrs.name
             )
         else:
-            event_dir = self.database_input_path / "events" / self.event.attrs.name
+            event_dir = self.database.events.get_database_path() / self.event.attrs.name
 
         # Create folders for offshore model
         self.simulation_paths_offshore[ii].mkdir(parents=True, exist_ok=True)
@@ -680,7 +649,7 @@ class Hazard:
                 )
                 offshore_model.add_spw_forcing(
                     historical_hurricane=self.event,
-                    database_path=base_path,
+                    database_path=self.database.base_path,
                     model_dir=self.simulation_paths_offshore[ii],
                 )
                 # save created spw file in the event directory
@@ -820,8 +789,8 @@ class Hazard:
                         or self.site.attrs.obs_point[ii].file is not None
                     ):
                         if self.site.attrs.obs_point[ii].file is not None:
-                            file = self.database_input_path.parent.joinpath(
-                                "static", self.site.attrs.obs_point[ii].file
+                            file = self.database.static_path.joinpath(
+                                self.site.attrs.obs_point[ii].file
                             )
                         else:
                             file = None
@@ -866,8 +835,8 @@ class Hazard:
             # read SFINCS model
             model = SfincsAdapter(model_root=sim_path, site=self.site)
             # dem file for high resolution flood depth map
-            demfile = self.database_input_path.parent.joinpath(
-                "static", "dem", self.site.attrs.dem.filename
+            demfile = self.database.static_path.joinpath(
+                "dem", self.site.attrs.dem.filename
             )
 
             # read max. water level
@@ -1013,8 +982,8 @@ class Hazard:
 
             # write geotiff
             # dem file for high resolution flood depth map
-            demfile = self.database_input_path.parent.joinpath(
-                "static", "dem", self.site.attrs.dem.filename
+            demfile = self.database.static_path.joinpath(
+                "dem", self.site.attrs.dem.filename
             )
             # writing the geotiff to the scenario results folder
             dummymodel = SfincsAdapter(

--- a/flood_adapt/object_model/scenario.py
+++ b/flood_adapt/object_model/scenario.py
@@ -20,7 +20,7 @@ class Scenario(IScenario):
     database_input_path: Union[str, os.PathLike]
 
     def init_object_model(self) -> "Scenario":
-        """Create a Direct Impact object"""
+        """Create a Direct Impact object."""
         from flood_adapt.dbs_controller import (
             Database,  # TODO: Fix circular import and move to top of file. There is too much entanglement between classes to fix this now
         )

--- a/flood_adapt/object_model/scenario.py
+++ b/flood_adapt/object_model/scenario.py
@@ -27,7 +27,9 @@ class Scenario(IScenario):
 
         database = Database()
         self.site_info = database.site
-        self.results_path = database.scenarios.get_database_path(get_input_path=False).joinpath(self.attrs.name)
+        self.results_path = database.scenarios.get_database_path(
+            get_input_path=False
+        ).joinpath(self.attrs.name)
         self.direct_impacts = DirectImpacts(
             scenario=self.attrs,
             database=database,

--- a/flood_adapt/object_model/scenario.py
+++ b/flood_adapt/object_model/scenario.py
@@ -10,7 +10,6 @@ import tomli_w
 from flood_adapt.object_model.direct_impacts import DirectImpacts
 from flood_adapt.object_model.hazard.hazard import ScenarioModel
 from flood_adapt.object_model.interface.scenarios import IScenario
-from flood_adapt.object_model.site import Site
 
 
 class Scenario(IScenario):
@@ -20,17 +19,19 @@ class Scenario(IScenario):
     direct_impacts: DirectImpacts
     database_input_path: Union[str, os.PathLike]
 
-    def init_object_model(self):
-        """Create a Direct Impact object."""
-        self.site_info = Site.load_file(
-            Path(self.database_input_path).parent / "static" / "site" / "site.toml"
+    def init_object_model(self) -> "Scenario":
+        """Create a Direct Impact object"""
+        from flood_adapt.dbs_controller import (
+            Database,  # TODO: Fix circular import and move to top of file. There is too much entanglement between classes to fix this now
         )
-        self.results_path = Path(self.database_input_path).parent.joinpath(
-            "output", "Scenarios", self.attrs.name
+
+        database = Database()
+        self.site_info = database.site
+        self.results_path = database.output_path.joinpath("Scenarios", self.attrs.name
         )
         self.direct_impacts = DirectImpacts(
             scenario=self.attrs,
-            database_input_path=Path(self.database_input_path),
+            database=database,
             results_path=self.results_path,
         )
         return self

--- a/flood_adapt/object_model/scenario.py
+++ b/flood_adapt/object_model/scenario.py
@@ -27,8 +27,7 @@ class Scenario(IScenario):
 
         database = Database()
         self.site_info = database.site
-        self.results_path = database.output_path.joinpath("Scenarios", self.attrs.name
-        )
+        self.results_path = database.output_path.joinpath("Scenarios", self.attrs.name)
         self.direct_impacts = DirectImpacts(
             scenario=self.attrs,
             database=database,

--- a/flood_adapt/object_model/scenario.py
+++ b/flood_adapt/object_model/scenario.py
@@ -27,7 +27,7 @@ class Scenario(IScenario):
 
         database = Database()
         self.site_info = database.site
-        self.results_path = database.output_path.joinpath("Scenarios", self.attrs.name)
+        self.results_path = database.scenarios.get_database_path(get_input_path=False).joinpath(self.attrs.name)
         self.direct_impacts = DirectImpacts(
             scenario=self.attrs,
             database=database,


### PR DESCRIPTION
These are all to get more consistent naming in the code (no more accidental capitals/non-capitals)
- Fix input, output, static and base path in the database
- Use these paths in the code
- Use the get function in Hazards and DirectImpacts
- Extend the database classes to automatically give the path to it's corresponding directory