### PR TITLE
Move delete crashed runs var to Settings class

### DIFF
--- a/flood_adapt/__init__.py
+++ b/flood_adapt/__init__.py
@@ -6,8 +6,3 @@ FloodAdaptLogging()  # Initialize logging once for the entire package
 
 __version__ = "0.1.1"
 SRC_DIR: Path = Path(__file__).parent
-
-
-# this will be a part of Settings() when that PR is merged (https://github.com/Deltares-research/FloodAdapt/pull/546)
-# Set this to False to disable the deletion of crashed/corrupted runs.
-DELETE_CRASHED_RUNS = True

--- a/flood_adapt/config.py
+++ b/flood_adapt/config.py
@@ -94,7 +94,8 @@ class Settings(BaseSettings):
     delete_crashed_runs: bool = Field(
         default=True,
         env="DELETE_CRASHED_RUNS",
-        description="Whether to delete crashed/corrupted runs immediately after they are detected.",
+        description="Whether to delete the output of crashed/corrupted runs. Be careful when setting this to False, as it may lead to a broken database that cannot be read in anymore.",
+        exclude=True,
     )
 
     @computed_field

--- a/flood_adapt/config.py
+++ b/flood_adapt/config.py
@@ -48,6 +48,8 @@ class Settings(BaseSettings):
         The root directory of the database.
     system_folder : Path
         The root directory of the system folder containing the kernels.
+    delete_crashed_runs : bool
+        Whether to delete crashed/corrupted runs immediately after they are detected.
 
     Properties
     ----------
@@ -88,6 +90,11 @@ class Settings(BaseSettings):
         default=SRC_DIR / "system",
         env="SYSTEM_FOLDER",
         description="The path of the system folder containing the kernels that run the calculations.",
+    )
+    delete_crashed_runs: bool = Field(
+        default=True,
+        env="DELETE_CRASHED_RUNS",
+        description="Whether to delete crashed/corrupted runs immediately after they are detected.",
     )
 
     @computed_field

--- a/flood_adapt/dbs_controller.py
+++ b/flood_adapt/dbs_controller.py
@@ -7,13 +7,15 @@ from typing import Any, Union
 import geopandas as gpd
 import numpy as np
 import pandas as pd
-import plotly.express as px
-import plotly.graph_objects as go
-import xarray as xr
 from cht_cyclones.tropical_cyclone import TropicalCyclone
 from geopandas import GeoDataFrame
+from plotly.express import line
+from plotly.express.colors import sample_colorscale
+from plotly.graph_objects import Figure, Scatter
+from plotly.subplots import make_subplots
+from xarray import open_dataarray, open_dataset
 
-from flood_adapt import DELETE_CRASHED_RUNS
+from flood_adapt.config import Settings
 from flood_adapt.dbs_classes.dbs_benefit import DbsBenefit
 from flood_adapt.dbs_classes.dbs_event import DbsEvent
 from flood_adapt.dbs_classes.dbs_measure import DbsMeasure
@@ -293,10 +295,10 @@ class Database(IDatabase):
             }
         )
 
-        colors = px.colors.sample_colorscale(
+        colors = sample_colorscale(
             "rainbow", [n / (ncolors - 1) for n in range(ncolors)]
         )
-        fig = px.line(
+        fig = line(
             df,
             x="Year",
             y=f"Sea level rise [{self.site.attrs.gui.default_length_units}]",
@@ -363,7 +365,7 @@ class Database(IDatabase):
         gui_units = self.site.attrs.gui.default_length_units
 
         # Plot actual thing
-        fig = px.line(wl_df + self.site.attrs.water_level.msl.height.convert(gui_units))
+        fig = line(wl_df + self.site.attrs.water_level.msl.height.convert(gui_units))
 
         # plot reference water levels
         fig.add_hline(
@@ -465,7 +467,7 @@ class Database(IDatabase):
             xlim2 = pd.to_datetime(event.attrs.time.end_time)
 
         # Plot actual thing
-        fig = px.line(data_frame=df)
+        fig = line(data_frame=df)
 
         # fig.update_traces(marker={"line": {"color": "#000000", "width": 2}})
 
@@ -532,10 +534,10 @@ class Database(IDatabase):
             xlim2 = pd.to_datetime(event.attrs.time.end_time)
 
         # Plot actual thing
-        fig = go.Figure()
+        fig = Figure()
         for ii, col in enumerate(df.columns):
             fig.add_trace(
-                go.Scatter(
+                Scatter(
                     x=df.index,
                     y=df[col],
                     name=river_descriptions[ii],
@@ -614,14 +616,12 @@ class Database(IDatabase):
 
         # Plot actual thing
         # Create figure with secondary y-axis
-        import plotly.graph_objects as go
-        from plotly.subplots import make_subplots
 
         fig = make_subplots(specs=[[{"secondary_y": True}]])
 
         # Add traces
         fig.add_trace(
-            go.Scatter(
+            Scatter(
                 x=df.index,
                 y=df["speed"],
                 name="Wind speed",
@@ -631,7 +631,7 @@ class Database(IDatabase):
         )
 
         fig.add_trace(
-            go.Scatter(
+            Scatter(
                 x=df.index, y=df["direction"], name="Wind direction", mode="markers"
             ),
             secondary_y=True,
@@ -825,7 +825,7 @@ class Database(IDatabase):
                 "Flooding",
                 "max_water_level_map.nc",
             )
-            map = xr.open_dataarray(map_path)
+            map = open_dataarray(map_path)
 
             zsmax = map.to_numpy()
 
@@ -835,7 +835,7 @@ class Database(IDatabase):
                 "Flooding",
                 f"RP_{return_period:04d}_maps.nc",
             )
-            zsmax = xr.open_dataset(file_path)["risk_map"][:, :].to_numpy().T
+            zsmax = open_dataset(file_path)["risk_map"][:, :].to_numpy().T
         return zsmax
 
     def get_fiat_footprints(self, scenario_name: str) -> GeoDataFrame:
@@ -1037,7 +1037,7 @@ class Database(IDatabase):
             - does not have a corresponding input
 
         """
-        if not DELETE_CRASHED_RUNS:
+        if not Settings().delete_crashed_runs:
             return
 
         scn_input_path = self.scenarios.get_database_path()

--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -278,19 +278,20 @@ class Hazard:
                         run_success = False
                         break
 
-        if Settings().delete_crashed_runs and not run_success:
-            # Remove all files in the simulation folder except for the log files
-            for simulation_path in self.simulation_paths:
-                for subdir, _, files in os.walk(simulation_path):
-                    for file in files:
-                        if not file.endswith(".log"):
-                            os.remove(os.path.join(subdir, file))
+        if not run_success:
+            if Settings().delete_crashed_runs:
+                # Remove all files in the simulation folder except for the log files
+                for simulation_path in self.simulation_paths:
+                    for subdir, _, files in os.walk(simulation_path):
+                        for file in files:
+                            if not file.endswith(".log"):
+                                os.remove(os.path.join(subdir, file))
 
-            # Remove all empty directories in the simulation folder (so only folders with log files remain)
-            for simulation_path in self.simulation_paths:
-                for subdir, _, files in os.walk(simulation_path):
-                    if not files:
-                        os.rmdir(subdir)
+                # Remove all empty directories in the simulation folder (so only folders with log files remain)
+                for simulation_path in self.simulation_paths:
+                    for subdir, _, files in os.walk(simulation_path):
+                        if not files:
+                            os.rmdir(subdir)
             raise RuntimeError("SFINCS model failed to run.")
 
     def run_sfincs_offshore(self, ii: int):

--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -12,7 +12,6 @@ import xarray as xr
 from noaa_coops.station import COOPSAPIError
 from numpy import matlib
 
-from flood_adapt import DELETE_CRASHED_RUNS
 from flood_adapt.config import Settings
 from flood_adapt.integrator.sfincs_adapter import SfincsAdapter
 from flood_adapt.log import FloodAdaptLogging
@@ -279,7 +278,7 @@ class Hazard:
                         run_success = False
                         break
 
-        if DELETE_CRASHED_RUNS and not run_success:
+        if Settings().delete_crashed_runs and not run_success:
             # Remove all files in the simulation folder except for the log files
             for simulation_path in self.simulation_paths:
                 for subdir, _, files in os.walk(simulation_path):


### PR DESCRIPTION
Usage:

from windows terminal:
```bash
set DELETE_CRASHED_RUNS=False
python floodadapt_run.py
```

from linux terminal:
```
export DELETE_CRASHED_RUNS=True
python floodadapt_run.py
```

from a python file
```python
from flood_adapt.config import Settings
# Put this somewhere in initialization
Settings(
  delete_crashed_runs=False
)
... # the rest of the script
```

Any time Settings() is called, 
1. It first reads the arguments it was given.
2. Then it fills unset fields with environment variables.
3. If there are still unset fields, it will use the defaults defined in the Settings class. 
4. Then it will run all validators, and update the environment with its current state.