### PR TITLE
chore(site): Rename objects for consistency

### DIFF
--- a/flood_adapt/object_model/interface/events.py
+++ b/flood_adapt/object_model/interface/events.py
@@ -137,11 +137,14 @@ class SurgeSource(str, Enum):
     shape = "shape"
 
 
+class SurgeShape(Enum):
+    gaussian = "gaussian"
+
 class SurgeModel(BaseModel):
     """BaseModel describing the expected variables and data types for harmonic tide parameters of synthetic model."""
 
     source: SurgeSource
-    shape_type: Optional[str] = "gaussian"
+    shape_type: SurgeShape = SurgeShape.gaussian
     shape_duration: Optional[float] = None
     shape_peak_time: Optional[float] = None
     shape_peak: Optional[UnitfulLength] = None
@@ -162,7 +165,7 @@ class EventModel(BaseModel):  # add WindModel etc as this is shared among all? t
     """BaseModel describing the expected variables and data types of attributes common to all event types."""
 
     name: str = Field(..., min_length=1, pattern='^[^<>:"/\\\\|?* ]*$')
-    description: Optional[str] = ""
+    description: str = ""
     mode: Mode
     template: Template
     timing: Timing

--- a/flood_adapt/object_model/interface/measures.py
+++ b/flood_adapt/object_model/interface/measures.py
@@ -64,7 +64,7 @@ class HazardMeasureModel(MeasureModel):
     @field_validator("polygon_file")
     @classmethod
     def validate_polygon_file(cls, v: Optional[str]) -> Optional[str]:
-        if len(v) == 0:
+        if v is None or len(v) == 0:
             raise ValueError("Polygon file path cannot be empty")
         return v
 

--- a/flood_adapt/object_model/interface/site.py
+++ b/flood_adapt/object_model/interface/site.py
@@ -297,7 +297,7 @@ class SiteModel(BaseModel):
     slr: SlrModel
     gui: GuiModel
     risk: RiskModel
-    flood_frequency: FloodFrequencyModel = FloodFrequencyModel(flooding_threshold= UnitfulLength(value=0.0, units=UnitTypesLength.meters))
+    flood_frequency: FloodFrequencyModel = FloodFrequencyModel(flooding_threshold= UnitfulLength(value=0.0, units=UnitTypesLength.metersd))
     dem: DemModel
     fiat: FiatModel
     tide_gauge: Optional[TideGaugeModel] = None

--- a/flood_adapt/object_model/interface/site.py
+++ b/flood_adapt/object_model/interface/site.py
@@ -25,7 +25,7 @@ class Cstype(str, Enum):
     spherical = "spherical"
 
 
-class Floodmap_type(str, Enum):
+class FloodmapType(str, Enum):
     """The accepted input for the variable floodmap in Site."""
 
     water_level = "water_level"
@@ -66,7 +66,7 @@ class WaterLevelReferenceModel(BaseModel):
     other: Optional[list[VerticalReferenceModel]] = []  # only for plotting
 
 
-class Cyclone_track_databaseModel(BaseModel):
+class CycloneTrackDatabaseModel(BaseModel):
     """The accepted input for the variable cyclone_track_database in Site."""
 
     file: str
@@ -103,7 +103,7 @@ class MapboxLayersModel(BaseModel):
     flood_map_colors: list[str]
     aggregation_dmg_bins: list[float]
     aggregation_dmg_colors: list[str]
-    footprints_dmg_type: DamageType = "absolute"
+    footprints_dmg_type: DamageType = DamageType.absolute
     footprints_dmg_bins: list[float]
     footprints_dmg_colors: list[str]
     svi_bins: Optional[list[float]] = []
@@ -193,9 +193,9 @@ class FiatModel(BaseModel):
     exposure_crs: str
     bfe: Optional[BFEModel] = None
     aggregation: list[AggregationModel]
-    floodmap_type: Floodmap_type
+    floodmap_type: FloodmapType
     non_building_names: Optional[list[str]]
-    damage_unit: Optional[str] = "$"
+    damage_unit: str = "$"
     building_footprints: Optional[str] = None
     roads_file_name: Optional[str] = None
     new_development_file_name: Optional[str] = None
@@ -221,7 +221,7 @@ class TideGaugeModel(BaseModel):
     """
 
     name: Optional[Union[int, str]] = None
-    description: Optional[str] = ""
+    description: str = ""
     source: TideGaugeSource
     ID: Optional[int] = None  # This is the only attribute that is currently used in FA!
     file: Optional[str] = None  # for locally stored data
@@ -242,14 +242,14 @@ class TideGaugeModel(BaseModel):
         return self
 
 
-class Obs_pointModel(BaseModel):
+class ObsPointModel(BaseModel):
     """The accepted input for the variable obs_point in Site.
 
     obs_points is used to define output locations in the hazard model, which will be plotted in the user interface.
     """
 
     name: Union[int, str]
-    description: Optional[str] = ""
+    description: str = ""
     ID: Optional[int] = (
         None  # if the observation station is also a tide gauge, this ID should be the same as for obs_station
     )
@@ -293,19 +293,16 @@ class SiteModel(BaseModel):
     lon: float
     sfincs: SfincsModel
     water_level: WaterLevelReferenceModel
-    cyclone_track_database: Optional[Cyclone_track_databaseModel] = None
+    cyclone_track_database: Optional[CycloneTrackDatabaseModel] = None
     slr: SlrModel
     gui: GuiModel
     risk: RiskModel
-    # TODO what should the default be
-    flood_frequency: Optional[FloodFrequencyModel] = {
-        "flooding_threshold": UnitfulLength(value=0.0, units="meters")
-    }
+    flood_frequency: FloodFrequencyModel = FloodFrequencyModel(flooding_threshold= UnitfulLength(value=0.0, units=UnitTypesLength.meters))
     dem: DemModel
     fiat: FiatModel
     tide_gauge: Optional[TideGaugeModel] = None
     river: Optional[list[RiverModel]] = None
-    obs_point: Optional[list[Obs_pointModel]] = None
+    obs_point: Optional[list[ObsPointModel]] = None
     benefits: BenefitsModel
     scs: Optional[SCSModel] = None  # optional for the US to use SCS rainfall curves
 


### PR DESCRIPTION
Some of the objects in the site model had inconsistent names (e.g. `Floodmap_type` vs `FloodmapType`) and some of the things had default values that contradicted the type hints. I came across this while working on the ascii issue and figured I might as well just fix it while I'm here. I'll add the ascii validators in a separate PR 