### PR TITLE
fix(misc): fix repo url in cliff.toml

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -34,7 +34,7 @@ footer = """
 
 trim = true
 postprocessors = [
-  { pattern = '<REPO>', replace = "https://github.com/savente93/ci-playground" }, # replace repository URL
+  { pattern = '<REPO>', replace = "https://github.com/Deltares-research/FloodAdapt" }, # replace repository URL
 ]
 
 # render body even when there are no releases to process


### PR DESCRIPTION
url of the repo in cliff.toml still had the ci-playground url where I developed this and I forgot to update it. This PR rectifies that.