### PR TITLE
feat(misc): add output as a conventional commit scope

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -15,6 +15,7 @@ rules:
       - dbs-builder
       - api
       - misc
+      - output
   type:
     level: error
     optional: false


### PR DESCRIPTION
a lot of the things we do in the post-processing are not necessarily connected with the models, and people using the backend might be interested in what changes in the outputs that flood adapt generates, so making a separate scope for this makes sense