### PR TITLE
feat(adapters,object-model): Allow for use of flood-depth maps in FIAT

### DIFF
--- a/flood_adapt/adapter/fiat_adapter.py
+++ b/flood_adapt/adapter/fiat_adapter.py
@@ -60,8 +60,8 @@ class FiatAdapter:
         gc.collect()
 
     def set_hazard(self, hazard: Hazard) -> None:
-        map_fn = hazard._get_flood_map_path()
         map_type = hazard.site.attrs.fiat.floodmap_type
+        map_fn = hazard._get_flood_map_path(map_type)
         var = "zsmax" if hazard.event_mode == Mode.risk else "risk_maps"
         is_risk = hazard.event_mode == Mode.risk
 

--- a/flood_adapt/database_builder/create_database.py
+++ b/flood_adapt/database_builder/create_database.py
@@ -26,7 +26,7 @@ from flood_adapt.api.static import read_database
 from flood_adapt.api.strategies import create_strategy, save_strategy
 from flood_adapt.config import Settings
 from flood_adapt.log import FloodAdaptLogging
-from flood_adapt.object_model.interface.site import Obs_pointModel, SlrModel
+from flood_adapt.object_model.interface.site import ObsPointModel, SlrModel
 from flood_adapt.object_model.io.unitfulvalue import UnitfulDischarge, UnitfulLength
 from flood_adapt.object_model.site import Site
 
@@ -195,7 +195,7 @@ class ConfigModel(BaseModel):
         Indicates if cyclones are enabled.
     cyclone_basin : Optional[Basins], default None
         The cyclone basin.
-    obs_point : Optional[list[Obs_pointModel]], default None
+    obs_point : Optional[list[ObsPointModel]], default None
         The list of observation point models.
     probabilistic_set : Optional[str], default None
         The probabilistic set path.
@@ -221,7 +221,7 @@ class ConfigModel(BaseModel):
     road_width: Optional[float] = 5
     cyclones: Optional[bool] = True
     cyclone_basin: Optional[Basins] = None
-    obs_point: Optional[list[Obs_pointModel]] = None
+    obs_point: Optional[list[ObsPointModel]] = None
     probabilistic_set: Optional[str] = None
     infographics: Optional[bool] = True
 

--- a/flood_adapt/dbs_controller.py
+++ b/flood_adapt/dbs_controller.py
@@ -995,6 +995,13 @@ class Database(IDatabase):
                         dirs_exist_ok=True,
                         ignore=shutil.ignore_patterns("simulations"),
                     )
+                    # Make sure names are consistent
+                    for path_new, path_old in zip(
+                        scenario.direct_impacts.hazard.water_depth_map,
+                        scn.direct_impacts.hazard.water_depth_map,
+                    ):
+                        path_new.parent.joinpath(path_old.name).rename(path_new)
+
                     self._logger.info(
                         f"Hazard simulation is used from the '{scn.attrs.name}' scenario"
                     )

--- a/flood_adapt/object_model/hazard/hazard.py
+++ b/flood_adapt/object_model/hazard/hazard.py
@@ -697,6 +697,7 @@ class Hazard:
             wl_map_fn = []
             for rp in self.site.attrs.risk.return_periods:
                 wl_map_fn.append(results_path.joinpath(f"RP_{rp:04d}_maps.nc"))
+            fd_map_fn = []
 
         self.water_level_map = wl_map_fn
         self.water_depth_map = fd_map_fn


### PR DESCRIPTION
Changes that were required to allow the use of flood-depths files instead of water levels ones. This allows the use of area calculation method in FIAT with more accuracy.