### PR TITLE
fix(misc): remove Settings() instantiation from module level code

### DIFF
--- a/flood_adapt/api/measures.py
+++ b/flood_adapt/api/measures.py
@@ -4,7 +4,6 @@ import geopandas as gpd
 import pandas as pd
 
 from flood_adapt.dbs_classes.database import Database
-from flood_adapt.misc.config import Settings
 from flood_adapt.object_model.direct_impact.measure.buyout import Buyout
 from flood_adapt.object_model.direct_impact.measure.elevate import Elevate
 from flood_adapt.object_model.direct_impact.measure.floodproof import FloodProof
@@ -192,7 +191,7 @@ def calculate_polygon_area(gdf: gpd.GeoDataFrame, site: Site) -> float:
 def calculate_volume(
     area: us.UnitfulArea,
     height: us.UnitfulHeight = us.UnitfulHeight(
-        value=0.0, units=Settings().unit_system.length
+        value=0.0, units=us.UnitTypesLength.meters
     ),
     percent_area: float = 100.0,
 ) -> float:

--- a/flood_adapt/object_model/hazard/event/hurricane.py
+++ b/flood_adapt/object_model/hazard/event/hurricane.py
@@ -9,7 +9,6 @@ from cht_cyclones.tropical_cyclone import TropicalCyclone
 from pydantic import BaseModel
 from shapely.affinity import translate
 
-from flood_adapt import Settings
 from flood_adapt.object_model.hazard.event.template_event import Event, EventModel
 from flood_adapt.object_model.hazard.forcing.rainfall import RainfallTrack
 from flood_adapt.object_model.hazard.forcing.wind import WindTrack
@@ -32,10 +31,10 @@ class TranslationModel(BaseModel):
     """BaseModel describing the expected variables and data types for translation parameters of hurricane model."""
 
     eastwest_translation: us.UnitfulLength = us.UnitfulLength(
-        value=0.0, units=Settings().unit_system.distance
+        value=0.0, units=us.UnitTypesLength.meters
     )
     northsouth_translation: us.UnitfulLength = us.UnitfulLength(
-        value=0.0, units=Settings().unit_system.distance
+        value=0.0, units=us.UnitTypesLength.meters
     )
 
 


### PR DESCRIPTION
module level code gets executed when importing the module. This includes fn arguments, class attr defaults etc.
Since Settings() instantiation can raise, it shouldnt be executed if not 100% required