### PR TITLE
fix(adapters): Take out part that was creating single event output

### DIFF
--- a/flood_adapt/adapter/sfincs_adapter.py
+++ b/flood_adapt/adapter/sfincs_adapter.py
@@ -248,11 +248,6 @@ class SfincsAdapter(IHazardAdapter):
             for sim_path in sim_paths:
                 self.execute(sim_path)
 
-                # postprocess subevents to be able to calculate return periods
-                self.write_floodmap_geotiff(scenario, sim_path=sim_path)
-                self.plot_wl_obs(scenario, sim_path=sim_path)
-                self.write_water_level_map(scenario, sim_path=sim_path)
-
     def postprocess(self, scenario: IScenario):
         if not self.sfincs_completed(scenario):
             raise RuntimeError("SFINCS was not run successfully!")


### PR DESCRIPTION
There was a part that was run in the post-processing step of the sfincs adapter that was creating single event output for each event in the event_set, with the same name, essentially overwriting in each iteration the files. This is now deleted.