### PR TITLE
fix(object-model): Correcting units in gauge plotting

### DIFF
--- a/flood_adapt/object_model/hazard/forcing/plotting.py
+++ b/flood_adapt/object_model/hazard/forcing/plotting.py
@@ -172,7 +172,7 @@ def plot_waterlevel(
         return "", None
 
     logger.debug("Plotting water level data")
-
+    units = Settings().unit_system.length
     data = None
     try:
         if isinstance(waterlevel, WaterlevelGauged):
@@ -180,7 +180,7 @@ def plot_waterlevel(
                 raise ValueError("No tide gauge defined for this site.")
             data = TideGauge(
                 site.attrs.sfincs.tide_gauge
-            ).get_waterlevels_in_time_frame(event.attrs.time)
+            ).get_waterlevels_in_time_frame(event.attrs.time, units=units)
         elif isinstance(waterlevel, (WaterlevelCSV, WaterlevelSynthetic)):
             data = waterlevel.to_dataframe(event.attrs.time)
         else:
@@ -195,8 +195,6 @@ def plot_waterlevel(
         return "", None
 
     # Plot actual thing
-    units = Settings().unit_system.length
-
     fig = px.line(data + site.attrs.sfincs.water_level.msl.height.convert(units))
 
     # plot reference water levels

--- a/flood_adapt/object_model/hazard/forcing/tide_gauge.py
+++ b/flood_adapt/object_model/hazard/forcing/tide_gauge.py
@@ -67,7 +67,7 @@ class TideGauge(ITideGauge):
 
         gauge_data.columns = [f"waterlevel_{self.attrs.ID}"]
         gauge_data = gauge_data * us.UnitfulLength(
-            value=1.0, units=us.UnitTypesLength.meters
+            value=1.0, units=self.attrs.units
         ).convert(units)
 
         if out_path is not None:


### PR DESCRIPTION
Units were not correctly interpreted when plotting gauged water level data. There was no conversion done on the actual noaa time-series which are in meters, before plotting them in the html which should be in feet.