### PR TITLE
fix(adapters): updated waterlevel references in Sfincs adapter 

### DIFF
--- a/flood_adapt/adapter/sfincs_adapter.py
+++ b/flood_adapt/adapter/sfincs_adapter.py
@@ -1330,6 +1330,13 @@ class SfincsAdapter(IHazardAdapter):
                 df_ts[i + 1] = df_ts[name]
             df_ts.columns = list(range(1, len(gdf_locs) + 1))
 
+        # Add difference between msl and local datum to the water level
+        df_ts += self.settings.water_level.msl.height.convert(
+            us.UnitTypesLength(us.UnitTypesLength.meters)
+        ) - self.settings.water_level.localdatum.height.convert(
+            us.UnitTypesLength(us.UnitTypesLength.meters)
+        )
+
         # HydroMT function: set waterlevel forcing from time series
         self._model.set_forcing_1d(
             name="bzs", df_ts=df_ts, gdf_locs=gdf_locs, merge=False


### PR DESCRIPTION
now all waterlevel forcings that are added to the model are updated with +msl and -localdatum

How it used to be implemented: 
https://github.com/Deltares-research/FloodAdapt/blob/3cef1953d14f2eba8cde624a05fe3bd369210b21/flood_adapt/object_model/hazard/hazard.py#L432C12-L437C14