### PR TITLE
refactor(adapters): Use pydantic model for defining impact columns formatting

### DIFF
--- a/flood_adapt/adapter/fiat_adapter.py
+++ b/flood_adapt/adapter/fiat_adapter.py
@@ -809,6 +809,7 @@ class FiatAdapter(IImpactAdapter):
             aggregation_area_fn=aggregation_areas,
             attribute_names=attribute_names,
             label_names=label_names,
+            geom_name="new_development_area",
             **kwargs,
         )
 
@@ -1346,7 +1347,7 @@ class FiatAdapter(IImpactAdapter):
             self.outputs["table"].merge(
                 buildings[[FiatColumns.object_id, "geometry"]],
                 on=FiatColumns.object_id,
-                how="left",
+                how="inner",
             )
         )
 

--- a/flood_adapt/adapter/fiat_adapter.py
+++ b/flood_adapt/adapter/fiat_adapter.py
@@ -65,6 +65,10 @@ _IMPACT_COLUMNS = FiatColumns(
     segment_length="Segment Length",
 )
 
+_FIAT_COLUMNS: FiatColumns = get_fiat_columns(
+    fiat_version="0.2.1"
+)  # columns of FIAT # TODO add version from config
+
 
 class FiatAdapter(IImpactAdapter):
     """
@@ -100,9 +104,7 @@ class FiatAdapter(IImpactAdapter):
         self.delete_crashed_runs = delete_crashed_runs
         self._model = FiatModel(root=str(model_root.resolve()), mode="r")
         self._model.read()
-        self.fiat_columns = (
-            get_fiat_columns()
-        )  # columns of FIAT # TODO add version from config
+        self.fiat_columns = _FIAT_COLUMNS
         self.impact_columns = _IMPACT_COLUMNS  # columns of FA impact output
 
     @property
@@ -839,6 +841,7 @@ class FiatAdapter(IImpactAdapter):
             self.fiat_columns.aggregation_label.format(name=aggr.name)
             for aggr in self.config.aggregation
         ]
+        new_dev_geom_name = Path(self.config.new_development_file_name).stem
         # Use hydromt function
         self._model.exposure.setup_new_composite_areas(
             percent_growth=population_growth,
@@ -850,7 +853,7 @@ class FiatAdapter(IImpactAdapter):
             aggregation_area_fn=aggregation_areas,
             attribute_names=attribute_names,
             label_names=label_names,
-            geom_name="new_development_area",
+            geom_name=new_dev_geom_name,
             **kwargs,
         )
 

--- a/flood_adapt/adapter/fiat_adapter.py
+++ b/flood_adapt/adapter/fiat_adapter.py
@@ -55,6 +55,8 @@ _IMPACT_COLUMNS = FiatColumns(
     aggregation_label="Aggregation Label: {name}",
     inundation_depth="Inundation Depth",
     inundation_depth_rp="Inundation Depth ({years}Y)",
+    reduction_factor="Reduction Factor",
+    reduction_factor_rp="Reduction Factor ({years}Y)",
     damage="Damage: {name}",
     damage_rp="Damage: {name} ({years}Y)",
     total_damage="Total Damage",
@@ -1177,7 +1179,10 @@ class FiatAdapter(IImpactAdapter):
         # Check if type of metric configuration is available
         for metric_file in metric_config_paths:
             if metric_file.exists():
-                metrics_writer = MetricsFileWriter(metric_file)
+                metrics_writer = MetricsFileWriter(
+                    metric_file,
+                    aggregation_label_fmt=self.impact_columns.aggregation_label,
+                )
 
                 metrics_writer.parse_metrics_to_file(
                     df_results=self.outputs["table"],

--- a/flood_adapt/adapter/fiat_adapter.py
+++ b/flood_adapt/adapter/fiat_adapter.py
@@ -65,6 +65,7 @@ _IMPACT_COLUMNS = FiatColumns(
     segment_length="Segment Length",
 )
 
+# Define column naming of FIAT model
 _FIAT_COLUMNS: FiatColumns = get_fiat_columns(
     fiat_version="0.2.1"
 )  # columns of FIAT # TODO add version from config

--- a/flood_adapt/adapter/fiat_adapter.py
+++ b/flood_adapt/adapter/fiat_adapter.py
@@ -87,6 +87,8 @@ class FiatAdapter(IImpactAdapter):
     _model: FiatModel  # hydroMT-FIAT model
     config: Optional[FiatConfigModel] = None
     exe_path: Optional[os.PathLike] = None
+    fiat_columns: FiatColumns
+    impact_columns: FiatColumns
 
     def __init__(
         self,

--- a/flood_adapt/database_builder/create_database.py
+++ b/flood_adapt/database_builder/create_database.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel, Field
 from shapely.geometry import Polygon
 
 from flood_adapt import FloodAdaptLogging, Settings
-from flood_adapt.adapter.fiat_adapter import FiatColumns
+from flood_adapt.adapter.fiat_adapter import _FIAT_COLUMNS
 from flood_adapt.api.events import get_event_mode
 from flood_adapt.api.projections import create_projection, save_projection
 from flood_adapt.api.static import read_database
@@ -331,7 +331,7 @@ def spatial_join(
     if filter:
         layer_inds = objects_joined["index_right"].dropna().unique()
         layer = layer.iloc[np.sort(layer_inds)].reset_index(drop=True)
-    objects_joined = objects_joined[[FiatColumns.object_id, field_name]]
+    objects_joined = objects_joined[[_FIAT_COLUMNS.object_id, field_name]]
     # rename field if provided
     if rename:
         objects_joined = objects_joined.rename(columns={field_name: rename})
@@ -540,9 +540,9 @@ class DatabaseBuilder:
         )
         # Make sure in case of multiple values that the first is kept
         buildings_joined = (
-            buildings_joined.groupby(FiatColumns.object_id)
+            buildings_joined.groupby(_FIAT_COLUMNS.object_id)
             .first()
-            .sort_values(by=[FiatColumns.object_id])
+            .sort_values(by=[_FIAT_COLUMNS.object_id])
         )
         # Create folder
         bf_folder = Path(self.fiat_model.root).joinpath(
@@ -554,7 +554,7 @@ class DatabaseBuilder:
         building_footprints.to_file(geo_path)
         # Save to exposure csv
         exposure_csv = exposure_csv.merge(
-            buildings_joined, on=FiatColumns.object_id, how="left"
+            buildings_joined, on=_FIAT_COLUMNS.object_id, how="left"
         )
         exposure_csv.to_csv(self.exposure_csv_path, index=False)
         # Set model building footprints
@@ -596,8 +596,8 @@ class DatabaseBuilder:
 
         # Make sure only csv objects have geometries
         for i, geoms in enumerate(self.fiat_model.exposure.exposure_geoms):
-            keep = geoms["Object ID"].isin(
-                self.fiat_model.exposure.exposure_db["Object ID"]
+            keep = geoms[_FIAT_COLUMNS.object_id].isin(
+                self.fiat_model.exposure.exposure_db[_FIAT_COLUMNS.object_id]
             )
             geoms = geoms[keep].reset_index(drop=True)
             self.fiat_model.exposure.exposure_geoms[i] = geoms
@@ -666,14 +666,14 @@ class DatabaseBuilder:
                 # add column for connection
                 if not footprints_found:
                     exposure = self.fiat_model.exposure.exposure_db.set_index(
-                        FiatColumns.object_id
+                        _FIAT_COLUMNS.object_id
                     )
-                    build_geoms["BF_FID"] = build_geoms[FiatColumns.object_id]
-                    build_geoms = build_geoms.set_index(FiatColumns.object_id)
-                    build_geoms[FiatColumns.extraction_method] = "centroid"
+                    build_geoms["BF_FID"] = build_geoms[_FIAT_COLUMNS.object_id]
+                    build_geoms = build_geoms.set_index(_FIAT_COLUMNS.object_id)
+                    build_geoms[_FIAT_COLUMNS.extraction_method] = "centroid"
                     exposure["BF_FID"] = build_geoms["BF_FID"]
-                    exposure[FiatColumns.extraction_method] = build_geoms[
-                        FiatColumns.extraction_method
+                    exposure[_FIAT_COLUMNS.extraction_method] = build_geoms[
+                        _FIAT_COLUMNS.extraction_method
                     ]
                     exposure.reset_index().to_csv(self.exposure_csv_path, index=False)
                     footprints_found = True
@@ -734,9 +734,9 @@ class DatabaseBuilder:
             )
             # Make sure in case of multiple values that the max is kept
             buildings_joined = (
-                buildings_joined.groupby(FiatColumns.object_id)
+                buildings_joined.groupby(_FIAT_COLUMNS.object_id)
                 .max(self.config.bfe.field_name)
-                .sort_values(by=[FiatColumns.object_id])
+                .sort_values(by=[_FIAT_COLUMNS.object_id])
                 .reset_index()
             )
             # Create folder
@@ -774,20 +774,22 @@ class DatabaseBuilder:
                     self.buildings,
                     self._check_path(aggr.file),
                     aggr.field_name,
-                    rename=f"{FiatColumns.aggregation_label}{aggr_name}",
+                    rename=_FIAT_COLUMNS.aggregation_label.format(name=aggr_name),
                 )
                 aggr_path = Path(self.fiat_model.root).joinpath(
                     "exposure", "aggregation_areas", f"{Path(aggr.file).stem}.gpkg"
                 )
                 aggr_areas.to_file(aggr_path)
                 exposure_csv = exposure_csv.merge(
-                    buildings_joined, on=FiatColumns.object_id, how="left"
+                    buildings_joined, on=_FIAT_COLUMNS.object_id, how="left"
                 )
                 self.fiat_model.spatial_joins["aggregation_areas"].append(
                     {
                         "name": aggr_name,
                         "file": aggr_path.relative_to(self.fiat_model.root),
-                        "field_name": f"{FiatColumns.aggregation_label}{aggr_name}",
+                        "field_name": _FIAT_COLUMNS.aggregation_label.format(
+                            name=aggr_name
+                        ),
                         "equity": None,
                     }
                 )
@@ -821,10 +823,10 @@ class DatabaseBuilder:
                     self.buildings,
                     region,
                     "aggr_id",
-                    rename=f"{FiatColumns.aggregation_label}region",
+                    rename=_FIAT_COLUMNS.aggregation_label.format(name="region"),
                 )
                 exposure_csv = exposure_csv.merge(
-                    buildings_joined, on=FiatColumns.object_id, how="left"
+                    buildings_joined, on=_FIAT_COLUMNS.object_id, how="left"
                 )
                 exposure_csv.to_csv(self.exposure_csv_path, index=False)
                 self.logger.warning(
@@ -889,7 +891,7 @@ class DatabaseBuilder:
                     f"'SVI' column in the FIAT exposure csv will be filled by {Path(self.config.svi.file).as_posix()}."
                 )
             exposure_csv = exposure_csv.merge(
-                buildings_joined, on=FiatColumns.object_id, how="left"
+                buildings_joined, on=_FIAT_COLUMNS.object_id, how="left"
             )
             exposure_csv.to_csv(self.exposure_csv_path, index=False)
             # Create folder
@@ -937,14 +939,15 @@ class DatabaseBuilder:
                 self.config.fiat_roads_name
             )
             roads = self.fiat_model.exposure.exposure_geoms[roads_ind]
-            roads_path = Path(self.fiat_model.root).joinpath(
-                self.fiat_model.config["exposure"]["geom"]["file2"]
-            )
+            roads_geom = self.fiat_model.config["exposure"]["geom"][
+                f"file{roads_ind+1}"
+            ]
+            roads_path = Path(self.fiat_model.root).joinpath(roads_geom)
 
             # TODO do we need the lanes column?
-            if "Segment Length" not in exposure_csv.columns:
+            if _FIAT_COLUMNS.segment_length not in exposure_csv.columns:
                 self.logger.warning(
-                    "'Segment Length' column not present in the FIAT exposure csv. Road impact infometrics cannot be produced."
+                    f"'{_FIAT_COLUMNS.segment_length}' column not present in the FIAT exposure csv. Road impact infometrics cannot be produced."
                 )
 
             # TODO should this should be performed through hydromt-FIAT?
@@ -986,8 +989,10 @@ class DatabaseBuilder:
             building_footprints=str(
                 footprints_path.relative_to(self.static_path).as_posix()
             ),
-            roads_file_name="spatial2.gpkg" if self.roads else None,
-            new_development_file_name="spatial3.gpkg",  # TODO allow for different naming
+            roads_file_name=f"{self.config.fiat_roads_name}.gpkg"
+            if self.roads
+            else None,
+            new_development_file_name="new_development_area.gpkg",  # TODO allow for different naming
             save_simulation=False,  # default is not to save simulations
             svi=svi_config,
             infographics=True if self.config.infographics else False,
@@ -1225,19 +1230,19 @@ class DatabaseBuilder:
             )
 
             exposure.loc[
-                exposure[FiatColumns.primary_object_type] == "road",
-                FiatColumns.ground_floor_height,
+                exposure[_FIAT_COLUMNS.primary_object_type] == "road",
+                _FIAT_COLUMNS.ground_floor_height,
             ] = 0
             exposure = exposure.merge(
-                roads[[FiatColumns.object_id, "elev"]],
-                on=FiatColumns.object_id,
+                roads[[_FIAT_COLUMNS.object_id, "elev"]],
+                on=_FIAT_COLUMNS.object_id,
                 how="left",
             )
             exposure.loc[
-                exposure[FiatColumns.primary_object_type] == "road",
-                FiatColumns.ground_elevation,
+                exposure[_FIAT_COLUMNS.primary_object_type] == "road",
+                _FIAT_COLUMNS.ground_elevation,
             ] = exposure.loc[
-                exposure[FiatColumns.primary_object_type] == "road", "elev"
+                exposure[_FIAT_COLUMNS.primary_object_type] == "road", "elev"
             ]
             del exposure["elev"]
 
@@ -1254,14 +1259,14 @@ class DatabaseBuilder:
             * conversion_factor
         )
         exposure = exposure.merge(
-            points[[FiatColumns.object_id, "elev"]],
-            on=FiatColumns.object_id,
+            points[[_FIAT_COLUMNS.object_id, "elev"]],
+            on=_FIAT_COLUMNS.object_id,
             how="left",
         )
         exposure.loc[
-            exposure[FiatColumns.primary_object_type] != "road",
-            FiatColumns.ground_elevation,
-        ] = exposure.loc[exposure[FiatColumns.primary_object_type] != "road", "elev"]
+            exposure[_FIAT_COLUMNS.primary_object_type] != "road",
+            _FIAT_COLUMNS.ground_elevation,
+        ] = exposure.loc[exposure[_FIAT_COLUMNS.primary_object_type] != "road", "elev"]
         del exposure["elev"]
 
         exposure.to_csv(exposure_csv_path, index=False)
@@ -1869,7 +1874,7 @@ class DatabaseBuilder:
 
         # Clip the exposure geometries
         # Filter buildings and roads
-        road_inds = gdf[FiatColumns.primary_object_type].str.contains("road")
+        road_inds = gdf[_FIAT_COLUMNS.primary_object_type].str.contains("road")
         # Ensure road_inds is a boolean Series
         if not road_inds.dtype == bool:
             road_inds = road_inds.astype(bool)
@@ -1891,16 +1896,16 @@ class DatabaseBuilder:
                 self.config.fiat_roads_name
             )
             self.fiat_model.exposure.exposure_geoms[idx_buildings] = gdf_buildings[
-                [FiatColumns.object_id, "geometry"]
+                [_FIAT_COLUMNS.object_id, "geometry"]
             ]
             self.fiat_model.exposure.exposure_geoms[idx_roads] = gdf_roads[
-                [FiatColumns.object_id, "geometry"]
+                [_FIAT_COLUMNS.object_id, "geometry"]
             ]
             gdf = pd.concat([gdf_buildings, gdf_roads])
         else:
             gdf = gdf_buildings
             self.fiat_model.exposure.exposure_geoms[0] = gdf[
-                [FiatColumns.object_id, "geometry"]
+                [_FIAT_COLUMNS.object_id, "geometry"]
             ]
 
         # Save exposure dataframe

--- a/flood_adapt/object_model/interface/config/fiat.py
+++ b/flood_adapt/object_model/interface/config/fiat.py
@@ -77,7 +77,7 @@ class FiatConfigModel(BaseModel):
     damage_unit: str = "$"
     building_footprints: Optional[str] = None
     roads_file_name: Optional[str] = None
-    new_development_file_name: Optional[str] = None
+    new_development_file_name: Optional[str] = "new_development_area.gpkg"
     save_simulation: Optional[bool] = False
     svi: Optional[SVIModel] = None
     infographics: Optional[bool] = False

--- a/pixi.lock
+++ b/pixi.lock
@@ -59,7 +59,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/aa/804c1cf5077b6f17d752b23637d9ef53eaad77ea73ee43d4c12bff480e36/duckdb-1.1.3-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/54/b6/08ac4b8fdb684eb00537a39031844c34e5235a9455073fe2dd428fee0cde/fiat_toolbox-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/11/9c/f2477aaecda2dff726e51e4e9bea7ce1e807a9b3326f7eed829532f3d38c/fiat_toolbox-0.1.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/32/c1d53b4d77926414ffdf5bd38344e900e378ae9ccb2a65754cdb6d5344c2/fiona-1.10.1-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
@@ -70,7 +70,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c4/64/7d344cfcef5efddf9cf32f59af7f855828e9d74b5f862eddf5bfd9f25323/geopandas-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/15/cf2a69ade4b194aa524ac75112d5caac37414b20a3a03e6865dfe0bd1539/geopy-2.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/26/80c465432563e7f9485ac0a230a8810a8a9417b9507dc96e341613a1c33f/hydromt-0.10.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/92/72/5eac2d7fbe469516b1861773165b81b15f8d3ab0386718ea3f76a4b31ace/hydromt_fiat-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/bc/fdc237745fd05f7f8f6dcca93f81205bf8bde19e5e0e00007c76d6a8a646/hydromt_fiat-0.5.2-py3-none-any.whl
       - pypi: git+https://github.com/deltares/hydromt_sfincs#94b514e7355fc94b3a787eff4f27e278b61b7cdd
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/9d/0fb148dc4d6fa4a7dd1d8378168d9b4cd8d4560a6fbf6f0121c5fc34eb68/importlib_metadata-8.6.1-py3-none-any.whl
@@ -113,6 +113,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4e/d1/e4ed95fdd3ef13b78630280d9e9e240aeb65cc7c544ec57106149c3942fb/pprintpp-0.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/fa/aae8e10512b83de633f2646506a6d835b151edf4b30d18d73afd01447253/protobuf-5.29.3-cp310-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/7b/d7/7831438e6c3ebbfa6e01a927127a6cb42ad3ab844247f3c5b96bea25d73d/psutil-6.1.1-cp37-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/77/e62aebd343238863f2c9f080ad2ef6ace25c919c6ab383436b5b81cbeef7/pyarrow-19.0.1-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/ec/1fb891d8a2660716aadb2143235481d15ed1cbfe3ad669194690b0604492/pycountry-24.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/e7/26c14899a43c34e04a58e3772007afe79dbd64fac15d2fbaeedff24082f2/pycountry_convert-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
@@ -230,7 +231,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/aa/804c1cf5077b6f17d752b23637d9ef53eaad77ea73ee43d4c12bff480e36/duckdb-1.1.3-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/54/b6/08ac4b8fdb684eb00537a39031844c34e5235a9455073fe2dd428fee0cde/fiat_toolbox-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/11/9c/f2477aaecda2dff726e51e4e9bea7ce1e807a9b3326f7eed829532f3d38c/fiat_toolbox-0.1.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/32/c1d53b4d77926414ffdf5bd38344e900e378ae9ccb2a65754cdb6d5344c2/fiona-1.10.1-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
@@ -241,7 +242,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c4/64/7d344cfcef5efddf9cf32f59af7f855828e9d74b5f862eddf5bfd9f25323/geopandas-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/15/cf2a69ade4b194aa524ac75112d5caac37414b20a3a03e6865dfe0bd1539/geopy-2.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/26/80c465432563e7f9485ac0a230a8810a8a9417b9507dc96e341613a1c33f/hydromt-0.10.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/92/72/5eac2d7fbe469516b1861773165b81b15f8d3ab0386718ea3f76a4b31ace/hydromt_fiat-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/bc/fdc237745fd05f7f8f6dcca93f81205bf8bde19e5e0e00007c76d6a8a646/hydromt_fiat-0.5.2-py3-none-any.whl
       - pypi: git+https://github.com/deltares/hydromt_sfincs#94b514e7355fc94b3a787eff4f27e278b61b7cdd
       - pypi: https://files.pythonhosted.org/packages/9f/cb/18326d2d89ad3b0dd143da971e77afd1e6ca6674f1b1c3df4b6bec6279fc/id-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
@@ -293,6 +294,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4e/d1/e4ed95fdd3ef13b78630280d9e9e240aeb65cc7c544ec57106149c3942fb/pprintpp-0.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/fa/aae8e10512b83de633f2646506a6d835b151edf4b30d18d73afd01447253/protobuf-5.29.3-cp310-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/7b/d7/7831438e6c3ebbfa6e01a927127a6cb42ad3ab844247f3c5b96bea25d73d/psutil-6.1.1-cp37-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/77/e62aebd343238863f2c9f080ad2ef6ace25c919c6ab383436b5b81cbeef7/pyarrow-19.0.1-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/ec/1fb891d8a2660716aadb2143235481d15ed1cbfe3ad669194690b0604492/pycountry-24.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/e7/26c14899a43c34e04a58e3772007afe79dbd64fac15d2fbaeedff24082f2/pycountry_convert-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
@@ -414,7 +416,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f2/eb/58d4e0eccdc7b3523c062d008ad9eef28edccf88591d1a78659c809fe6e8/duckdb-1.1.3-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/54/b6/08ac4b8fdb684eb00537a39031844c34e5235a9455073fe2dd428fee0cde/fiat_toolbox-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/11/9c/f2477aaecda2dff726e51e4e9bea7ce1e807a9b3326f7eed829532f3d38c/fiat_toolbox-0.1.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/0d/914fd3c4c32043c2c512fa5021e83b2348e1b7a79365d75a0a37cb545362/fiona-1.10.1-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
@@ -425,7 +427,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c4/64/7d344cfcef5efddf9cf32f59af7f855828e9d74b5f862eddf5bfd9f25323/geopandas-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/15/cf2a69ade4b194aa524ac75112d5caac37414b20a3a03e6865dfe0bd1539/geopy-2.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/26/80c465432563e7f9485ac0a230a8810a8a9417b9507dc96e341613a1c33f/hydromt-0.10.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/92/72/5eac2d7fbe469516b1861773165b81b15f8d3ab0386718ea3f76a4b31ace/hydromt_fiat-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/bc/fdc237745fd05f7f8f6dcca93f81205bf8bde19e5e0e00007c76d6a8a646/hydromt_fiat-0.5.2-py3-none-any.whl
       - pypi: git+https://github.com/deltares/hydromt_sfincs#94b514e7355fc94b3a787eff4f27e278b61b7cdd
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/9d/0fb148dc4d6fa4a7dd1d8378168d9b4cd8d4560a6fbf6f0121c5fc34eb68/importlib_metadata-8.6.1-py3-none-any.whl
@@ -468,6 +470,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4e/d1/e4ed95fdd3ef13b78630280d9e9e240aeb65cc7c544ec57106149c3942fb/pprintpp-0.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/fa/aae8e10512b83de633f2646506a6d835b151edf4b30d18d73afd01447253/protobuf-5.29.3-cp310-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/7b/d7/7831438e6c3ebbfa6e01a927127a6cb42ad3ab844247f3c5b96bea25d73d/psutil-6.1.1-cp37-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/16/33/2a67c0f783251106aeeee516f4806161e7b481f7d744d0d643d2f30230a5/pyarrow-19.0.1-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/ec/1fb891d8a2660716aadb2143235481d15ed1cbfe3ad669194690b0604492/pycountry-24.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/e7/26c14899a43c34e04a58e3772007afe79dbd64fac15d2fbaeedff24082f2/pycountry_convert-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
@@ -584,7 +587,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/aa/804c1cf5077b6f17d752b23637d9ef53eaad77ea73ee43d4c12bff480e36/duckdb-1.1.3-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/54/b6/08ac4b8fdb684eb00537a39031844c34e5235a9455073fe2dd428fee0cde/fiat_toolbox-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/11/9c/f2477aaecda2dff726e51e4e9bea7ce1e807a9b3326f7eed829532f3d38c/fiat_toolbox-0.1.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/ec/00d68c4ddfedfe64159999e5f8a98fb8442729a63e2077eb9dcd89623d27/filelock-3.17.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/32/c1d53b4d77926414ffdf5bd38344e900e378ae9ccb2a65754cdb6d5344c2/fiona-1.10.1-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
@@ -596,7 +599,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c4/64/7d344cfcef5efddf9cf32f59af7f855828e9d74b5f862eddf5bfd9f25323/geopandas-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/15/cf2a69ade4b194aa524ac75112d5caac37414b20a3a03e6865dfe0bd1539/geopy-2.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/26/80c465432563e7f9485ac0a230a8810a8a9417b9507dc96e341613a1c33f/hydromt-0.10.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/92/72/5eac2d7fbe469516b1861773165b81b15f8d3ab0386718ea3f76a4b31ace/hydromt_fiat-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/bc/fdc237745fd05f7f8f6dcca93f81205bf8bde19e5e0e00007c76d6a8a646/hydromt_fiat-0.5.2-py3-none-any.whl
       - pypi: git+https://github.com/deltares/hydromt_sfincs#94b514e7355fc94b3a787eff4f27e278b61b7cdd
       - pypi: https://files.pythonhosted.org/packages/74/a1/68a395c17eeefb04917034bd0a1bfa765e7654fa150cca473d669aa3afb5/identify-2.6.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
@@ -642,6 +645,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/07/92/caae8c86e94681b42c246f0bca35c059a2f0529e5b92619f6aba4cf7e7b6/pre_commit-3.8.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/fa/aae8e10512b83de633f2646506a6d835b151edf4b30d18d73afd01447253/protobuf-5.29.3-cp310-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/7b/d7/7831438e6c3ebbfa6e01a927127a6cb42ad3ab844247f3c5b96bea25d73d/psutil-6.1.1-cp37-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/77/e62aebd343238863f2c9f080ad2ef6ace25c919c6ab383436b5b81cbeef7/pyarrow-19.0.1-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/ec/1fb891d8a2660716aadb2143235481d15ed1cbfe3ad669194690b0604492/pycountry-24.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/e7/26c14899a43c34e04a58e3772007afe79dbd64fac15d2fbaeedff24082f2/pycountry_convert-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
@@ -775,7 +779,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7b/8f/c4d9bafc34ad7ad5d8dc16dd1347ee0e507a52c3adb6bfa8887e1c6a26ba/executing-2.2.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/90/2b/0817a2b257fe88725c25589d89aec060581aabf668707a8d03b2e9e0cb2a/fastjsonschema-2.21.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/54/b6/08ac4b8fdb684eb00537a39031844c34e5235a9455073fe2dd428fee0cde/fiat_toolbox-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/11/9c/f2477aaecda2dff726e51e4e9bea7ce1e807a9b3326f7eed829532f3d38c/fiat_toolbox-0.1.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/32/c1d53b4d77926414ffdf5bd38344e900e378ae9ccb2a65754cdb6d5344c2/fiona-1.10.1-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
@@ -792,7 +796,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/26/80c465432563e7f9485ac0a230a8810a8a9417b9507dc96e341613a1c33f/hydromt-0.10.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/92/72/5eac2d7fbe469516b1861773165b81b15f8d3ab0386718ea3f76a4b31ace/hydromt_fiat-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/bc/fdc237745fd05f7f8f6dcca93f81205bf8bde19e5e0e00007c76d6a8a646/hydromt_fiat-0.5.2-py3-none-any.whl
       - pypi: git+https://github.com/deltares/hydromt_sfincs#94b514e7355fc94b3a787eff4f27e278b61b7cdd
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/9d/0fb148dc4d6fa4a7dd1d8378168d9b4cd8d4560a6fbf6f0121c5fc34eb68/importlib_metadata-8.6.1-py3-none-any.whl
@@ -879,6 +883,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/61/fa/aae8e10512b83de633f2646506a6d835b151edf4b30d18d73afd01447253/protobuf-5.29.3-cp310-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/7b/d7/7831438e6c3ebbfa6e01a927127a6cb42ad3ab844247f3c5b96bea25d73d/psutil-6.1.1-cp37-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/77/e62aebd343238863f2c9f080ad2ef6ace25c919c6ab383436b5b81cbeef7/pyarrow-19.0.1-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/ec/1fb891d8a2660716aadb2143235481d15ed1cbfe3ad669194690b0604492/pycountry-24.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/e7/26c14899a43c34e04a58e3772007afe79dbd64fac15d2fbaeedff24082f2/pycountry_convert-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
@@ -1021,7 +1026,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/bf/fd60001b3abc5222d8eaa4a204cd8c0ae78e75adc688f33ce4bf25b7fafa/fasteners-0.19-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/54/b6/08ac4b8fdb684eb00537a39031844c34e5235a9455073fe2dd428fee0cde/fiat_toolbox-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/11/9c/f2477aaecda2dff726e51e4e9bea7ce1e807a9b3326f7eed829532f3d38c/fiat_toolbox-0.1.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ca/a3/57d33c2f16a2a6b27911d83301a697ed1491dca48d2f1dd2ed3b58a66244/fiona-1.10.1-cp310-cp310-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
@@ -1032,7 +1037,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c4/64/7d344cfcef5efddf9cf32f59af7f855828e9d74b5f862eddf5bfd9f25323/geopandas-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/15/cf2a69ade4b194aa524ac75112d5caac37414b20a3a03e6865dfe0bd1539/geopy-2.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/26/80c465432563e7f9485ac0a230a8810a8a9417b9507dc96e341613a1c33f/hydromt-0.10.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/92/72/5eac2d7fbe469516b1861773165b81b15f8d3ab0386718ea3f76a4b31ace/hydromt_fiat-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/bc/fdc237745fd05f7f8f6dcca93f81205bf8bde19e5e0e00007c76d6a8a646/hydromt_fiat-0.5.2-py3-none-any.whl
       - pypi: git+https://github.com/deltares/hydromt_sfincs#94b514e7355fc94b3a787eff4f27e278b61b7cdd
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/9d/0fb148dc4d6fa4a7dd1d8378168d9b4cd8d4560a6fbf6f0121c5fc34eb68/importlib_metadata-8.6.1-py3-none-any.whl
@@ -1075,6 +1080,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4e/d1/e4ed95fdd3ef13b78630280d9e9e240aeb65cc7c544ec57106149c3942fb/pprintpp-0.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/fa/aae8e10512b83de633f2646506a6d835b151edf4b30d18d73afd01447253/protobuf-5.29.3-cp310-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/7b/d7/7831438e6c3ebbfa6e01a927127a6cb42ad3ab844247f3c5b96bea25d73d/psutil-6.1.1-cp37-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/54/e3/d5cfd7654084e6c0d9c3ce949e5d9e0ccad569ae1e2d5a68a3ec03b2be89/pyarrow-19.0.1-cp310-cp310-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/ec/1fb891d8a2660716aadb2143235481d15ed1cbfe3ad669194690b0604492/pycountry-24.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/e7/26c14899a43c34e04a58e3772007afe79dbd64fac15d2fbaeedff24082f2/pycountry_convert-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
@@ -1188,7 +1194,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/aa/804c1cf5077b6f17d752b23637d9ef53eaad77ea73ee43d4c12bff480e36/duckdb-1.1.3-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/54/b6/08ac4b8fdb684eb00537a39031844c34e5235a9455073fe2dd428fee0cde/fiat_toolbox-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/11/9c/f2477aaecda2dff726e51e4e9bea7ce1e807a9b3326f7eed829532f3d38c/fiat_toolbox-0.1.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/95/32/c1d53b4d77926414ffdf5bd38344e900e378ae9ccb2a65754cdb6d5344c2/fiona-1.10.1-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
@@ -1199,7 +1205,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c4/64/7d344cfcef5efddf9cf32f59af7f855828e9d74b5f862eddf5bfd9f25323/geopandas-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/15/cf2a69ade4b194aa524ac75112d5caac37414b20a3a03e6865dfe0bd1539/geopy-2.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/26/80c465432563e7f9485ac0a230a8810a8a9417b9507dc96e341613a1c33f/hydromt-0.10.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/92/72/5eac2d7fbe469516b1861773165b81b15f8d3ab0386718ea3f76a4b31ace/hydromt_fiat-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/bc/fdc237745fd05f7f8f6dcca93f81205bf8bde19e5e0e00007c76d6a8a646/hydromt_fiat-0.5.2-py3-none-any.whl
       - pypi: git+https://github.com/deltares/hydromt_sfincs#94b514e7355fc94b3a787eff4f27e278b61b7cdd
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/9d/0fb148dc4d6fa4a7dd1d8378168d9b4cd8d4560a6fbf6f0121c5fc34eb68/importlib_metadata-8.6.1-py3-none-any.whl
@@ -1242,6 +1248,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4e/d1/e4ed95fdd3ef13b78630280d9e9e240aeb65cc7c544ec57106149c3942fb/pprintpp-0.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/fa/aae8e10512b83de633f2646506a6d835b151edf4b30d18d73afd01447253/protobuf-5.29.3-cp310-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/7b/d7/7831438e6c3ebbfa6e01a927127a6cb42ad3ab844247f3c5b96bea25d73d/psutil-6.1.1-cp37-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/ff/77/e62aebd343238863f2c9f080ad2ef6ace25c919c6ab383436b5b81cbeef7/pyarrow-19.0.1-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/ec/1fb891d8a2660716aadb2143235481d15ed1cbfe3ad669194690b0604492/pycountry-24.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/e7/26c14899a43c34e04a58e3772007afe79dbd64fac15d2fbaeedff24082f2/pycountry_convert-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
@@ -1356,7 +1363,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f2/eb/58d4e0eccdc7b3523c062d008ad9eef28edccf88591d1a78659c809fe6e8/duckdb-1.1.3-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/54/b6/08ac4b8fdb684eb00537a39031844c34e5235a9455073fe2dd428fee0cde/fiat_toolbox-0.1.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/11/9c/f2477aaecda2dff726e51e4e9bea7ce1e807a9b3326f7eed829532f3d38c/fiat_toolbox-0.1.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/0d/914fd3c4c32043c2c512fa5021e83b2348e1b7a79365d75a0a37cb545362/fiona-1.10.1-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fe/5e/3be305568fe5f34448807976dc82fc151d76c3e0e03958f34770286278c1/flexparser-0.4-py3-none-any.whl
@@ -1367,7 +1374,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c4/64/7d344cfcef5efddf9cf32f59af7f855828e9d74b5f862eddf5bfd9f25323/geopandas-1.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e5/15/cf2a69ade4b194aa524ac75112d5caac37414b20a3a03e6865dfe0bd1539/geopy-2.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d3/26/80c465432563e7f9485ac0a230a8810a8a9417b9507dc96e341613a1c33f/hydromt-0.10.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/92/72/5eac2d7fbe469516b1861773165b81b15f8d3ab0386718ea3f76a4b31ace/hydromt_fiat-0.4.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/db/bc/fdc237745fd05f7f8f6dcca93f81205bf8bde19e5e0e00007c76d6a8a646/hydromt_fiat-0.5.2-py3-none-any.whl
       - pypi: git+https://github.com/deltares/hydromt_sfincs#94b514e7355fc94b3a787eff4f27e278b61b7cdd
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/79/9d/0fb148dc4d6fa4a7dd1d8378168d9b4cd8d4560a6fbf6f0121c5fc34eb68/importlib_metadata-8.6.1-py3-none-any.whl
@@ -1410,6 +1417,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4e/d1/e4ed95fdd3ef13b78630280d9e9e240aeb65cc7c544ec57106149c3942fb/pprintpp-0.4.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/fa/aae8e10512b83de633f2646506a6d835b151edf4b30d18d73afd01447253/protobuf-5.29.3-cp310-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/7b/d7/7831438e6c3ebbfa6e01a927127a6cb42ad3ab844247f3c5b96bea25d73d/psutil-6.1.1-cp37-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/16/33/2a67c0f783251106aeeee516f4806161e7b481f7d744d0d643d2f30230a5/pyarrow-19.0.1-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/b1/ec/1fb891d8a2660716aadb2143235481d15ed1cbfe3ad669194690b0604492/pycountry-24.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9b/e7/26c14899a43c34e04a58e3772007afe79dbd64fac15d2fbaeedff24082f2/pycountry_convert-0.7.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/13/a3/a812df4e2dd5696d1f351d58b8fe16a405b234ad2886a0dab9183fb78109/pycparser-2.22-py3-none-any.whl
@@ -2406,10 +2414,10 @@ packages:
   - pytest-benchmark ; extra == 'devel'
   - pytest-cache ; extra == 'devel'
   - validictory ; extra == 'devel'
-- pypi: https://files.pythonhosted.org/packages/54/b6/08ac4b8fdb684eb00537a39031844c34e5235a9455073fe2dd428fee0cde/fiat_toolbox-0.1.14-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/11/9c/f2477aaecda2dff726e51e4e9bea7ce1e807a9b3326f7eed829532f3d38c/fiat_toolbox-0.1.15-py3-none-any.whl
   name: fiat-toolbox
-  version: 0.1.14
-  sha256: 5ca26bc6945aa526587584fc4b7bbe66bee434a2fa4c18756e504b2e05d5d85e
+  version: 0.1.15
+  sha256: 64c5055c48a029adbe1df4cc553ef22d449e7f3302cab4b9b3921c9a114a91d4
   requires_dist:
   - numpy
   - pandas
@@ -2419,6 +2427,7 @@ packages:
   - geopandas
   - duckdb
   - validators
+  - pydantic
   requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/89/ec/00d68c4ddfedfe64159999e5f8a98fb8442729a63e2077eb9dcd89623d27/filelock-3.17.0-py3-none-any.whl
   name: filelock
@@ -2530,18 +2539,19 @@ packages:
 - pypi: .
   name: flood-adapt
   version: 0.2.0
-  sha256: 5e17655040ed7b6b03ddb67e53d3197ec2aee6c62a5ce3cfce4ceff91d4c3cd5
+  sha256: 71ee777a7e09e525d534cb842699e3bf1aaebeb59aaba69703fecf4d79804484
   requires_dist:
   - cht-cyclones
+  - cht-meteo
   - cht-observations
   - cht-tide
   - dask<2024.7.0
-  - fiat-toolbox
+  - fiat-toolbox==0.1.15
   - fiona
   - geojson
   - geopandas
   - jellyfish<1.0
-  - hydromt-fiat==0.4.2
+  - hydromt-fiat==0.5.2
   - hydromt-sfincs @ git+https://github.com/Deltares/hydromt_sfincs.git
   - numpy<2.0
   - numpy-financial
@@ -2981,10 +2991,10 @@ packages:
   - pytest-timeout ; extra == 'test'
   - xugrid ; extra == 'test'
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/92/72/5eac2d7fbe469516b1861773165b81b15f8d3ab0386718ea3f76a4b31ace/hydromt_fiat-0.4.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/db/bc/fdc237745fd05f7f8f6dcca93f81205bf8bde19e5e0e00007c76d6a8a646/hydromt_fiat-0.5.2-py3-none-any.whl
   name: hydromt-fiat
-  version: 0.4.2
-  sha256: 7151a144b16f52e998d1cbee6d3ecb7ecf9303dd43ce12b0a485b9a72a232b15
+  version: 0.5.2
+  sha256: 1834b0ebf3dbb6f85bbbc479a52186f6fe58366c9526957ccd9e55876be6075b
   requires_dist:
   - hydromt<1.0
   - geopandas
@@ -3003,6 +3013,8 @@ packages:
   - xarray-spatial
   - tqdm
   - pycountry-convert
+  - pyarrow
+  - dask<=2024.12.1
   - testpath ; extra == 'test'
   - responses ; extra == 'test'
   - pytest>=2.7.3 ; extra == 'test'
@@ -5198,6 +5210,39 @@ packages:
   sha256: 1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0
   requires_dist:
   - pytest ; extra == 'tests'
+- pypi: https://files.pythonhosted.org/packages/16/33/2a67c0f783251106aeeee516f4806161e7b481f7d744d0d643d2f30230a5/pyarrow-19.0.1-cp312-cp312-win_amd64.whl
+  name: pyarrow
+  version: 19.0.1
+  sha256: 5bd1618ae5e5476b7654c7b55a6364ae87686d4724538c24185bbb2952679960
+  requires_dist:
+  - pytest ; extra == 'test'
+  - hypothesis ; extra == 'test'
+  - cffi ; extra == 'test'
+  - pytz ; extra == 'test'
+  - pandas ; extra == 'test'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/54/e3/d5cfd7654084e6c0d9c3ce949e5d9e0ccad569ae1e2d5a68a3ec03b2be89/pyarrow-19.0.1-cp310-cp310-win_amd64.whl
+  name: pyarrow
+  version: 19.0.1
+  sha256: c6cb2335a411b713fdf1e82a752162f72d4a7b5dbc588e32aa18383318b05866
+  requires_dist:
+  - pytest ; extra == 'test'
+  - hypothesis ; extra == 'test'
+  - cffi ; extra == 'test'
+  - pytz ; extra == 'test'
+  - pandas ; extra == 'test'
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/ff/77/e62aebd343238863f2c9f080ad2ef6ace25c919c6ab383436b5b81cbeef7/pyarrow-19.0.1-cp311-cp311-win_amd64.whl
+  name: pyarrow
+  version: 19.0.1
+  sha256: 008a4009efdb4ea3d2e18f05cd31f9d43c388aad29c636112c2966605ba33466
+  requires_dist:
+  - pytest ; extra == 'test'
+  - hypothesis ; extra == 'test'
+  - cffi ; extra == 'test'
+  - pytz ; extra == 'test'
+  - pandas ; extra == 'test'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/b1/ec/1fb891d8a2660716aadb2143235481d15ed1cbfe3ad669194690b0604492/pycountry-24.6.1-py3-none-any.whl
   name: pycountry
   version: 24.6.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,13 @@ dependencies = [
     "cht-observations",
     "cht-tide",
     "dask<2024.7.0",  # The last version that still supports pandas 1.x, which we need until fiat-toolbox and noaa_cops become compatible with pandas 2.x
-    "fiat-toolbox",
+    "fiat-toolbox==0.1.15",
     "fiona",
     "geojson",
     "geopandas",
     "jellyfish<1.0",  # This is a dependency of us->hydromt-fiat, FloodAdapt doesnt use it directly. Remove when .whl files are available.
     # jellyfish v1.0 starts requiring rust as a dependency, which is fine if there are built .whl files. BUT THERE ARE NO BUILDS FOR WINDOWS YET.
-    "hydromt-fiat==0.4.2",
+    "hydromt-fiat==0.5.2",
     "hydromt-sfincs@ git+https://github.com/Deltares/hydromt_sfincs.git",
     "numpy < 2.0",
     "numpy-financial",

--- a/tests/test_adapter/test_fiat_adapter.py
+++ b/tests/test_adapter/test_fiat_adapter.py
@@ -77,7 +77,7 @@ class TestFiatAdapter:
         exp1 = exposure_scenario.loc[inds1, "Max Potential Damage: structure"]
         inds0 = exposure_template[_FIAT_COLUMNS.primary_object_type] != "road"
         exp0 = exposure_template.loc[
-            inds0, f"{_FIAT_COLUMNS.max_potential_damage}structure"
+            inds0, _FIAT_COLUMNS.max_potential_damage.format(name="structure")
         ]
         eg = test_scenario.impacts.socio_economic_change.attrs.economic_growth
         pg = (
@@ -107,7 +107,7 @@ class TestFiatAdapter:
                 / 100
             )
             * exposure_template.loc[
-                :, f"{_FIAT_COLUMNS.max_potential_damage}structure"
+                :, _FIAT_COLUMNS.max_potential_damage.format(name="structure")
             ].sum()
         )
 
@@ -194,7 +194,9 @@ class TestFiatAdapter:
             2
         ].attrs.property_type
         inds1 = (
-            exposure_template.loc[:, f"{_FIAT_COLUMNS.aggregation_label}{aggr_label}"]
+            exposure_template.loc[
+                :, _FIAT_COLUMNS.aggregation_label.format(name=aggr_label)
+            ]
             == aggr_name
         ) & (exposure_template.loc[:, _FIAT_COLUMNS.primary_object_type] == build_type)
         inds2 = (
@@ -203,7 +205,9 @@ class TestFiatAdapter:
 
         assert all(
             exposure_scenario.loc[inds2, "Damage Function: structure"]
-            != exposure_template.loc[inds1, f"{_FIAT_COLUMNS.damage_function}structure"]
+            != exposure_template.loc[
+                inds1, _FIAT_COLUMNS.damage_function.format(name="structure")
+            ]
         )
 
     def test_raise_datum(self, run_scenario_raise_datum):
@@ -228,7 +232,9 @@ class TestFiatAdapter:
             0
         ].attrs.property_type
         inds1 = (
-            exposure_template.loc[:, f"{_FIAT_COLUMNS.aggregation_label}{aggr_label}"]
+            exposure_template.loc[
+                :, _FIAT_COLUMNS.aggregation_label.format(name=aggr_label)
+            ]
             == aggr_name
         ) & (exposure_template.loc[:, _FIAT_COLUMNS.primary_object_type] == build_type)
         inds2 = (

--- a/tests/test_adapter/test_fiat_adapter.py
+++ b/tests/test_adapter/test_fiat_adapter.py
@@ -1,5 +1,6 @@
 import pandas as pd
 import pytest
+from fiat_toolbox import get_fiat_columns
 from pandas.testing import assert_frame_equal
 
 from flood_adapt.object_model.interface.path_builder import (
@@ -7,6 +8,8 @@ from flood_adapt.object_model.interface.path_builder import (
     db_path,
 )
 from flood_adapt.object_model.scenario import Scenario
+
+_FIAT_COLUMNS = get_fiat_columns()
 
 
 class TestFiatAdapter:
@@ -68,12 +71,14 @@ class TestFiatAdapter:
         assert len(exposure_scenario) > len(exposure_template)
 
         # check if growth has been applied correctly
-        inds1 = exposure_scenario["Object ID"].isin(exposure_template["Object ID"]) & (
-            exposure_scenario["Primary Object Type"] != "road"
-        )
-        exp1 = exposure_scenario.loc[inds1, "Max Potential Damage: Structure"]
-        inds0 = exposure_template["Primary Object Type"] != "road"
-        exp0 = exposure_template.loc[inds0, "Max Potential Damage: Structure"]
+        inds1 = exposure_scenario["Object ID"].isin(
+            exposure_template[_FIAT_COLUMNS.object_id]
+        ) & (exposure_scenario["Primary Object Type"] != "road")
+        exp1 = exposure_scenario.loc[inds1, "Max Potential Damage: structure"]
+        inds0 = exposure_template[_FIAT_COLUMNS.primary_object_type] != "road"
+        exp0 = exposure_template.loc[
+            inds0, f"{_FIAT_COLUMNS.max_potential_damage}structure"
+        ]
         eg = test_scenario.impacts.socio_economic_change.attrs.economic_growth
         pg = (
             test_scenario.impacts.socio_economic_change.attrs.population_growth_existing
@@ -85,12 +90,12 @@ class TestFiatAdapter:
 
         # check if new area max damage is implemented correctly
         inds_new_area = ~exposure_scenario["Object ID"].isin(
-            exposure_template["Object ID"]
+            exposure_template[_FIAT_COLUMNS.object_id]
         )
         assert (
             pytest.approx(
                 exposure_scenario.loc[
-                    inds_new_area, "Max Potential Damage: Structure"
+                    inds_new_area, "Max Potential Damage: structure"
                 ].sum()
             )
             == (
@@ -101,7 +106,9 @@ class TestFiatAdapter:
                 test_scenario.impacts.socio_economic_change.attrs.population_growth_new
                 / 100
             )
-            * exposure_template.loc[:, "Max Potential Damage: Structure"].sum()
+            * exposure_template.loc[
+                :, f"{_FIAT_COLUMNS.max_potential_damage}structure"
+            ].sum()
         )
 
         # check if buildings are elevated correctly
@@ -122,10 +129,11 @@ class TestFiatAdapter:
         bfes = pd.read_csv(db_path(TopLevelDir.static) / "bfe" / "bfe.csv")
 
         # Create a dataframe to save the initial object attributes
-        exposures = exposure_template.merge(bfes, on="Object ID")[
-            ["Object ID", "bfe", "Ground Floor Height"]
-        ].rename(columns={"Ground Floor Height": "Ground Floor Height 1"})
+        exposures = exposure_template.merge(bfes, on=_FIAT_COLUMNS.object_id)[
+            [_FIAT_COLUMNS.object_id, "bfe", _FIAT_COLUMNS.ground_floor_height]
+        ].rename(columns={_FIAT_COLUMNS.ground_floor_height: "Ground Floor Height 1"})
         # Merge with the adapted fiat model exposure
+        exposures = exposures.rename(columns={_FIAT_COLUMNS.object_id: "Object ID"})
         exposures = exposures.merge(exposure_scenario, on="Object ID").rename(
             columns={"Ground Floor Height": "Ground Floor Height 2"}
         )
@@ -173,7 +181,7 @@ class TestFiatAdapter:
             exposure_scenario.loc[:, f"Aggregation Label: {aggr_label}"] == aggr_name
         ) & (exposure_scenario.loc[:, "Primary Object Type"] == build_type)
 
-        assert all(exposure_scenario.loc[inds, "Max Potential Damage: Structure"] == 0)
+        assert all(exposure_scenario.loc[inds, "Max Potential Damage: structure"] == 0)
 
         # check if buildings are flood-proofed
         aggr_label = test_scenario.impacts.impact_strategy.measures[
@@ -186,15 +194,16 @@ class TestFiatAdapter:
             2
         ].attrs.property_type
         inds1 = (
-            exposure_template.loc[:, f"Aggregation Label: {aggr_label}"] == aggr_name
-        ) & (exposure_template.loc[:, "Primary Object Type"] == build_type)
+            exposure_template.loc[:, f"{_FIAT_COLUMNS.aggregation_label}{aggr_label}"]
+            == aggr_name
+        ) & (exposure_template.loc[:, _FIAT_COLUMNS.primary_object_type] == build_type)
         inds2 = (
             exposure_scenario.loc[:, f"Aggregation Label: {aggr_label}"] == aggr_name
         ) & (exposure_scenario.loc[:, "Primary Object Type"] == build_type)
 
         assert all(
-            exposure_scenario.loc[inds2, "Damage Function: Structure"]
-            != exposure_template.loc[inds1, "Damage Function: Structure"]
+            exposure_scenario.loc[inds2, "Damage Function: structure"]
+            != exposure_template.loc[inds1, f"{_FIAT_COLUMNS.damage_function}structure"]
         )
 
     def test_raise_datum(self, run_scenario_raise_datum):
@@ -219,8 +228,9 @@ class TestFiatAdapter:
             0
         ].attrs.property_type
         inds1 = (
-            exposure_template.loc[:, f"Aggregation Label: {aggr_label}"] == aggr_name
-        ) & (exposure_template.loc[:, "Primary Object Type"] == build_type)
+            exposure_template.loc[:, f"{_FIAT_COLUMNS.aggregation_label}{aggr_label}"]
+            == aggr_name
+        ) & (exposure_template.loc[:, _FIAT_COLUMNS.primary_object_type] == build_type)
         inds2 = (
             exposure_scenario.loc[:, f"Aggregation Label: {aggr_label}"] == aggr_name
         ) & (exposure_scenario.loc[:, "Primary Object Type"] == build_type)
@@ -228,7 +238,7 @@ class TestFiatAdapter:
         assert all(
             elev1 <= elev2
             for elev1, elev2 in zip(
-                exposure_template.loc[inds1, "Ground Floor Height"],
+                exposure_template.loc[inds1, _FIAT_COLUMNS.ground_floor_height],
                 exposure_scenario.loc[inds2, "Ground Floor Height"],
             )
         )

--- a/tests/test_api/test_static_data.py
+++ b/tests/test_api/test_static_data.py
@@ -16,8 +16,8 @@ def test_aggr_areas(test_db):
 
 def test_property_types(test_db):
     types = api_static.get_property_types()
-    expected_types = ["RES", "COM", "road", "all"]
+    expected_types = ["RES", "COM", "all"]
 
     assert isinstance(types, list)
-    assert len(types) == 4
+    assert len(types) == 3
     assert all(t in types for t in expected_types)


### PR DESCRIPTION
With this update the latest changes in fiat_toolbox are used. Now a FiatColumns class defines the expected FIAT columns and their string formatting. This way, one formatting is tighted to the FIAT output based on the FIAT version used, and one is tighted to the FloodAdapt output which can be defined in the FiatAdapter. 