### PR TITLE
fix(dbs-builder): make BenefitsModel and RiskModel in FiatModel optional

### DIFF
--- a/flood_adapt/config/fiat.py
+++ b/flood_adapt/config/fiat.py
@@ -198,18 +198,18 @@ class FiatModel(BaseModel):
 
     Attributes
     ----------
-    risk : RiskModel
-        Configuration of probabilistic risk runs.
+    risk : Optional[RiskModel]
+        Configuration of probabilistic risk runs. default=None
     config : FiatConfigModel
         Configuration for the FIAT model.
-    benefits : BenefitsModel
-        Configuration for running benefit calculations.
+    benefits : Optional[BenefitsModel]
+        Configuration for running benefit calculations. default=None
     """
 
-    risk: RiskModel
-
     config: FiatConfigModel
-    benefits: BenefitsModel
+
+    benefits: Optional[BenefitsModel] = None
+    risk: Optional[RiskModel] = None
 
     @staticmethod
     def read_toml(path: Path) -> "FiatModel":

--- a/flood_adapt/database_builder/database_builder.py
+++ b/flood_adapt/database_builder/database_builder.py
@@ -379,6 +379,7 @@ class DatabaseBuilder:
 
     _has_roads: bool = False
     _aggregation_areas: Optional[list] = None
+    _probabilistic_set_name: Optional[str] = None
 
     def __init__(self, config: ConfigModel, overwrite: bool = True):
         self.config = config

--- a/tests/test_database_builder/test_database_builder.py
+++ b/tests/test_database_builder/test_database_builder.py
@@ -108,7 +108,26 @@ class TestDataBaseBuilder:
         # Assert
         assert risk.return_periods == mock_config.return_periods
 
-    def test_create_risk_model_returns_default_risk(self, mock_config: ConfigModel):
+    def test_create_risk_model_returns_default_risk_if_risk_event(
+        self, mock_config: ConfigModel
+    ):
+        # Arrange
+        mock_config.probabilistic_set = str(
+            self.db_path / "input" / "events" / "test_set"
+        )
+        mock_config.return_periods = []
+        builder = DatabaseBuilder(mock_config)
+        builder._probabilistic_set_name = "test_set"
+
+        # Act
+        risk = builder.create_risk_model()
+
+        # Assert
+        assert risk == RiskModel()
+
+    def test_create_risk_model_returns_none_if_no_risk_event_and_no_rp(
+        self, mock_config: ConfigModel
+    ):
         # Arrange
         mock_config.return_periods = []
         builder = DatabaseBuilder(mock_config)
@@ -117,11 +136,13 @@ class TestDataBaseBuilder:
         risk = builder.create_risk_model()
 
         # Assert
-        assert risk == RiskModel()
+        assert risk is None
 
     def test_add_probabilistic_set(self, mock_config: ConfigModel):
         # Arrange
-        mock_config.probabilistic_set = self.db_path / "input" / "events" / "test_set"
+        mock_config.probabilistic_set = str(
+            self.db_path / "input" / "events" / "test_set"
+        )
         builder = DatabaseBuilder(mock_config)
         builder.add_probabilistic_set()
 
@@ -129,7 +150,9 @@ class TestDataBaseBuilder:
 
     def test_create_benefits_with_test_set(self, mock_config: ConfigModel):
         # Arrange
-        mock_config.probabilistic_set = self.db_path / "input" / "events" / "test_set"
+        mock_config.probabilistic_set = str(
+            self.db_path / "input" / "events" / "test_set"
+        )
         builder = DatabaseBuilder(mock_config)
         builder._probabilistic_set_name = "test_set"
 

--- a/tests/test_flood_adapt.py
+++ b/tests/test_flood_adapt.py
@@ -449,7 +449,7 @@ class TestOutput:
 
     def test_impact_get_aggregation(self, completed_scenario: tuple[FloodAdapt, str]):
         test_fa, scn_name = completed_scenario
-        aggr_areas = test_fa.get_aggregation_areas(scn_name)
+        aggr_areas = test_fa.get_aggregated_impacts(scn_name)
         assert isinstance(aggr_areas, dict)
 
 


### PR DESCRIPTION
## Explanation
Sarah found bugs while writing notebooks. This fixes them.

The problem was that there was no event set, but fiat was expecting it.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
