### PR TITLE
fix(dbs-controller): Corrected saving object validation issue which did not allow editing 

### DIFF
--- a/flood_adapt/dbs_classes/dbs_template.py
+++ b/flood_adapt/dbs_classes/dbs_template.py
@@ -285,10 +285,6 @@ class DbsTemplate(AbstractDatabaseElement[T_OBJECTMODEL]):
             Raise error if name is already in use.
         """
         # Check if the object exists
-        if object_model.name in self.list_objects()["name"]:
-            raise ValueError(
-                f"{self.display_name}: '{object_model.name}' already exists. Choose a different name."
-            )
         object_exists = object_model.name in self.list_objects()["name"]
 
         # If you want to overwrite the object, and the object already exists, first delete it. If it exists and you


### PR DESCRIPTION
## Issue addressed
Fixes issue where you cannot edit an object.

## Explanation
There was a check for the name of the object already existing that was taking place all the time while it should not when overwrite is true

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Updated documentation if needed

## Additional Notes (optional)
N/A
