### PR TITLE
refactor(dbs-controller): Take out edit methods from API and add overwrite option in save method

### DIFF
--- a/docs/examples/events/database_manipulation.ipynb
+++ b/docs/examples/events/database_manipulation.ipynb
@@ -156,7 +156,7 @@
     "print(\"Description before `Edit`:\", unedited_event.description)\n",
     "\n",
     "unedited_event.description = f\"Updated description\"\n",
-    "fa.edit_event(event=unedited_event)\n",
+    "fa.save_event(event=unedited_event, overwrite=True)\n",
     "\n",
     "edited_event = fa.get_event(event_name)\n",
     "print(\"Description after `Edit`:\", edited_event.description)"

--- a/flood_adapt/dbs_classes/dbs_benefit.py
+++ b/flood_adapt/dbs_classes/dbs_benefit.py
@@ -59,27 +59,6 @@ class DbsBenefit(DbsTemplate[Benefit]):
         if output_path.exists():
             shutil.rmtree(output_path, ignore_errors=True)
 
-    def edit(self, benefit: Benefit):
-        """Edits an already existing benefit in the database.
-
-        Parameters
-        ----------
-        benefit : Benefit
-            benefit to be edited in the database
-
-        Raises
-        ------
-        ValueError
-            Raise error if name is already in use.
-        """
-        # Check if it is possible to edit the benefit.
-        super().edit(benefit)
-
-        # Delete output if edited
-        output_path = self.output_path / benefit.name
-        if output_path.exists():
-            shutil.rmtree(output_path, ignore_errors=True)
-
     def get_runner(self, name: str) -> BenefitRunner:
         return BenefitRunner(self._database, self.get(name))
 

--- a/flood_adapt/dbs_classes/dbs_scenario.py
+++ b/flood_adapt/dbs_classes/dbs_scenario.py
@@ -58,28 +58,6 @@ class DbsScenario(DbsTemplate[Scenario]):
         if (self.output_path / name).exists():
             shutil.rmtree(self.output_path / name, ignore_errors=False)
 
-    def edit(self, scenario: Scenario):
-        """Edits an already existing scenario in the database.
-
-        Parameters
-        ----------
-        scenario : Scenario
-            scenario to be edited in the database
-
-        Raises
-        ------
-        ValueError
-            Raise error if name is already in use.
-        """
-        # Check if it is possible to edit the scenario. This then also covers checking whether the
-        # scenario is already used in a higher level object. If this is the case, it cannot be edited.
-        super().edit(scenario)
-
-        # Delete output if edited
-        output_path = self.output_path / scenario.name
-        if output_path.exists():
-            shutil.rmtree(output_path, ignore_errors=True)
-
     def check_higher_level_usage(self, name: str) -> list[str]:
         """Check if a scenario is used in a benefit.
 

--- a/flood_adapt/dbs_classes/dbs_template.py
+++ b/flood_adapt/dbs_classes/dbs_template.py
@@ -133,30 +133,6 @@ class DbsTemplate(AbstractDatabaseElement[T_OBJECTMODEL]):
             self.input_path / object_model.name / f"{object_model.name}.toml",
         )
 
-    def edit(self, object_model: T_OBJECTMODEL):
-        """Edit an already existing object in the database.
-
-        Parameters
-        ----------
-        object_model : Object
-            object to be edited in the database
-
-        Raises
-        ------
-        ValueError
-            Raise error if name is already in use.
-        """
-        # Check if the object exists
-        if object_model.name not in self.summarize_objects()["name"]:
-            raise ValueError(
-                f"{self.display_name}: '{object_model.name}' does not exist. You cannot edit an {self.display_name.lower()} that does not exist."
-            )
-
-        # Check if it is possible to delete the object by saving with overwrite. This then
-        # also covers checking whether the object is a standard object, is already used in
-        # a higher level object. If any of these are the case, it cannot be deleted.
-        self.save(object_model, overwrite=True)
-
     def delete(self, name: str, toml_only: bool = False):
         """Delete an already existing object in the database.
 

--- a/flood_adapt/dbs_classes/interface/element.py
+++ b/flood_adapt/dbs_classes/interface/element.py
@@ -86,22 +86,6 @@ class AbstractDatabaseElement(ABC, Generic[T_OBJECT_MODEL]):
         pass
 
     @abstractmethod
-    def edit(self, object_model: T_OBJECT_MODEL):
-        """Edits an already existing object in the database.
-
-        Parameters
-        ----------
-        object : IObject
-            object to be edited in the database
-
-        Raises
-        ------
-        ValueError
-            Raise error if name is already in use.
-        """
-        pass
-
-    @abstractmethod
     def delete(self, name: str, toml_only: bool = False):
         """Delete an already existing object in the database.
 

--- a/flood_adapt/flood_adapt.py
+++ b/flood_adapt/flood_adapt.py
@@ -129,6 +129,8 @@ class FloodAdapt:
         ----------
         measure : Measure
             The measure object to save.
+        overwrite : bool, optional
+            Whether to overwrite an existing event with the same name (default is False).
 
         Raises
         ------
@@ -136,21 +138,6 @@ class FloodAdapt:
             If the measure object is not valid.
         """
         self.database.measures.save(measure, overwrite=overwrite)
-
-    def edit_measure(self, measure: Measure) -> None:
-        """Edit a measure object in the database.
-
-        Parameters
-        ----------
-        measure : Measure
-            The measure object to edit.
-
-        Raises
-        ------
-        ValueError
-            If the measure object does not exist.
-        """
-        self.database.measures.edit(measure)
 
     def delete_measure(self, name: str) -> None:
         """Delete an measure from the database.
@@ -253,7 +240,7 @@ class FloodAdapt:
         """
         return Strategy(**attrs)
 
-    def save_strategy(self, strategy: Strategy) -> None:
+    def save_strategy(self, strategy: Strategy, overwrite: bool = False) -> None:
         """
         Save a strategy object to the database.
 
@@ -261,6 +248,8 @@ class FloodAdapt:
         ----------
         strategy : Strategy
             The strategy object to save.
+        overwrite : bool, optional
+            Whether to overwrite an existing event with the same name (default is False).
 
         Raises
         ------
@@ -268,7 +257,7 @@ class FloodAdapt:
             If the strategy object is not valid.
             If the strategy object already exists.
         """
-        self.database.strategies.save(strategy)
+        self.database.strategies.save(strategy, overwrite=overwrite)
 
     def delete_strategy(self, name: str) -> None:
         """
@@ -383,23 +372,7 @@ class FloodAdapt:
         ValueError
             If the event object is not valid.
         """
-        self.database.events.save(event, overwrite)
-
-    def edit_event(self, event: Event) -> None:
-        """Edit an event object in the database.
-
-        Parameters
-        ----------
-        event : Event
-            The event object to edit.
-
-        Raises
-        ------
-        ValueError
-            If the event object does not exist.
-            If the event is used in a scenario.
-        """
-        self.database.events.edit(event)
+        self.database.events.save(event, overwrite=overwrite)
 
     def delete_event(self, name: str) -> None:
         """Delete an event from the database.
@@ -521,35 +494,22 @@ class FloodAdapt:
         """
         return Projection(**attrs)
 
-    def save_projection(self, projection: Projection) -> None:
+    def save_projection(self, projection: Projection, overwrite: bool = False) -> None:
         """Save a projection object to the database.
 
         Parameters
         ----------
         projection : Projection
             The projection object to save.
+        overwrite : bool, optional
+            Whether to overwrite an existing event with the same name (default is False).
 
         Raises
         ------
         ValueError
             If the projection object is not valid.
         """
-        self.database.projections.save(projection)
-
-    def edit_projection(self, projection: Projection) -> None:
-        """Edit a projection object in the database.
-
-        Parameters
-        ----------
-        projection : Projection
-            The projection object to edit.
-
-        Raises
-        ------
-        ValueError
-            If the projection object does not exist.
-        """
-        self.database.projections.edit(projection)
+        self.database.projections.save(projection, overwrite=overwrite)
 
     def delete_projection(self, name: str) -> None:
         """Delete a projection from the database.
@@ -678,13 +638,17 @@ class FloodAdapt:
         """
         return Scenario(**attrs)
 
-    def save_scenario(self, scenario: Scenario) -> tuple[bool, str]:
+    def save_scenario(
+        self, scenario: Scenario, overwrite: bool = False
+    ) -> tuple[bool, str]:
         """Save the scenario to the database.
 
         Parameters
         ----------
         scenario : Scenario
             The scenario to save.
+        overwrite : bool, optional
+            Whether to overwrite an existing event with the same name (default is False).
 
         Returns
         -------
@@ -694,25 +658,10 @@ class FloodAdapt:
             The error message if the scenario was not saved successfully.
         """
         try:
-            self.database.scenarios.save(scenario)
+            self.database.scenarios.save(scenario, overwrite=overwrite)
             return True, ""
         except Exception as e:
             return False, str(e)
-
-    def edit_scenario(self, scenario: Scenario) -> None:
-        """Edit a scenario object in the database.
-
-        Parameters
-        ----------
-        scenario : Scenario
-            The scenario object to edit.
-
-        Raises
-        ------
-        ValueError
-            If the scenario object does not exist.
-        """
-        self.database.scenarios.edit(scenario)
 
     def delete_scenario(self, name: str) -> None:
         """Delete a scenario from the database.
@@ -1139,35 +1088,22 @@ class FloodAdapt:
         """
         return Benefit(**attrs)
 
-    def save_benefit(self, benefit: Benefit) -> None:
+    def save_benefit(self, benefit: Benefit, overwrite: bool = False) -> None:
         """Save a benefit object to the database.
 
         Parameters
         ----------
         benefit : Benefit
             The benefit object to save.
+        overwrite : bool, optional
+            Whether to overwrite an existing event with the same name (default is False).
 
         Raises
         ------
         ValueError
             If the benefit object is not valid.
         """
-        self.database.benefits.save(benefit)
-
-    def edit_benefit(self, benefit: Benefit) -> None:
-        """Edit a benefit object in the database.
-
-        Parameters
-        ----------
-        benefit : Benefit
-            The benefit object to edit.
-
-        Raises
-        ------
-        ValueError
-            If the benefit object does not exist.
-        """
-        self.database.benefits.edit(benefit)
+        self.database.benefits.save(benefit, overwrite=overwrite)
 
     def delete_benefit(self, name: str) -> None:
         """Delete a benefit object from the database.

--- a/flood_adapt/flood_adapt.py
+++ b/flood_adapt/flood_adapt.py
@@ -130,7 +130,7 @@ class FloodAdapt:
         measure : Measure
             The measure object to save.
         overwrite : bool, optional
-            Whether to overwrite an existing event with the same name (default is False).
+            Whether to overwrite an existing measure with the same name (default is False).
 
         Raises
         ------
@@ -249,7 +249,7 @@ class FloodAdapt:
         strategy : Strategy
             The strategy object to save.
         overwrite : bool, optional
-            Whether to overwrite an existing event with the same name (default is False).
+            Whether to overwrite an existing strategy with the same name (default is False).
 
         Raises
         ------
@@ -502,7 +502,7 @@ class FloodAdapt:
         projection : Projection
             The projection object to save.
         overwrite : bool, optional
-            Whether to overwrite an existing event with the same name (default is False).
+            Whether to overwrite an existing projection with the same name (default is False).
 
         Raises
         ------
@@ -648,7 +648,7 @@ class FloodAdapt:
         scenario : Scenario
             The scenario to save.
         overwrite : bool, optional
-            Whether to overwrite an existing event with the same name (default is False).
+            Whether to overwrite an existing scenario with the same name (default is False).
 
         Returns
         -------
@@ -1096,7 +1096,7 @@ class FloodAdapt:
         benefit : Benefit
             The benefit object to save.
         overwrite : bool, optional
-            Whether to overwrite an existing event with the same name (default is False).
+            Whether to overwrite an existing benefit with the same name (default is False).
 
         Raises
         ------

--- a/flood_adapt/flood_adapt.py
+++ b/flood_adapt/flood_adapt.py
@@ -368,20 +368,22 @@ class FloodAdapt:
         """
         return EventSet(**attrs, sub_events=sub_events)
 
-    def save_event(self, event: Event) -> None:
+    def save_event(self, event: Event, overwrite: bool = False) -> None:
         """Save an event object to the database.
 
         Parameters
         ----------
         event : Event
             The event object to save.
+        overwrite : bool, optional
+            Whether to overwrite an existing event with the same name (default is False).
 
         Raises
         ------
         ValueError
             If the event object is not valid.
         """
-        self.database.events.save(event)
+        self.database.events.save(event, overwrite)
 
     def edit_event(self, event: Event) -> None:
         """Edit an event object in the database.

--- a/tests/test_flood_adapt.py
+++ b/tests/test_flood_adapt.py
@@ -609,7 +609,7 @@ class TestBenefits:
         benefit_dict_new["implementation_cost"] = 30000000
         benefit_dict_new["annual_maint_cost"] = 0
         benefit = test_fa.create_benefit(benefit_dict_new)
-        test_fa.edit_benefit(benefit)
+        test_fa.save_benefit(benefit, overwrite=True)
         test_fa.run_benefit("benefit_raise_properties_2080")
 
         benefit = test_fa.get_benefit("benefit_raise_properties_2080")


### PR DESCRIPTION
## Issue addressed
The edit method was essentially a save with overwrite, which was now added as an option in the save method, in order to completely take out all the edit methods for each object.

## Explanation
Explain how you addressed the bug/feature request, what choices you made and why.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
