### PR TITLE
refactor(dbs-controller): Enhance standard object protection handling

### DIFF
--- a/flood_adapt/config/site.py
+++ b/flood_adapt/config/site.py
@@ -66,6 +66,11 @@ class Site(BaseModel):
             "description": self.description,
             "lat": self.lat,
             "lon": self.lon,
+            "standard_objects": {
+                "events": self.standard_objects.events,
+                "projections": self.standard_objects.projections,
+                "strategies": self.standard_objects.strategies,
+            },
             "components": {},
         }
 

--- a/flood_adapt/dbs_classes/database.py
+++ b/flood_adapt/dbs_classes/database.py
@@ -123,11 +123,17 @@ class Database(IDatabase):
 
         # Initialize the different database objects
         self._static = DbsStatic(self)
-        self._events = DbsEvent(self)
+        self._events = DbsEvent(
+            self, standard_objects=self.site.standard_objects.events
+        )
         self._scenarios = DbsScenario(self)
-        self._strategies = DbsStrategy(self)
+        self._strategies = DbsStrategy(
+            self, standard_objects=self.site.standard_objects.strategies
+        )
         self._measures = DbsMeasure(self)
-        self._projections = DbsProjection(self)
+        self._projections = DbsProjection(
+            self, standard_objects=self.site.standard_objects.projections
+        )
         self._benefits = DbsBenefit(self)
 
         # Delete any unfinished/crashed scenario output

--- a/flood_adapt/dbs_classes/dbs_event.py
+++ b/flood_adapt/dbs_classes/dbs_event.py
@@ -33,26 +33,6 @@ class DbsEvent(DbsTemplate[Event]):
         # Load event
         return EventFactory.load_file(event_path)
 
-    def _check_standard_objects(self, name: str) -> bool:
-        """Check if an event is a standard event.
-
-        Parameters
-        ----------
-        name : str
-            name of the event to be checked
-
-        Returns
-        -------
-        bool
-            True if the event is a standard event, False otherwise
-        """
-        # Check if event is a standard event
-        if self._database.site.standard_objects:
-            if self._database.site.standard_objects.events:
-                if name in self._database.site.standard_objects.events:
-                    return True
-        return False
-
     def check_higher_level_usage(self, name: str) -> list[str]:
         """Check if an event is used in a scenario.
 

--- a/flood_adapt/dbs_classes/dbs_projection.py
+++ b/flood_adapt/dbs_classes/dbs_projection.py
@@ -7,27 +7,6 @@ class DbsProjection(DbsTemplate[Projection]):
     display_name = "Projection"
     _object_class = Projection
 
-    def _check_standard_objects(self, name: str) -> bool:
-        """Check if a projection is a standard projection.
-
-        Parameters
-        ----------
-        name : str
-            name of the projection to be checked
-
-        Raises
-        ------
-        ValueError
-            Raise error if projection is a standard projection.
-        """
-        # Check if projection is a standard projection
-        if self._database.site.standard_objects:
-            if self._database.site.standard_objects.projections:
-                if name in self._database.site.standard_objects.projections:
-                    return True
-
-        return False
-
     def check_higher_level_usage(self, name: str) -> list[str]:
         """Check if a projection is used in a scenario.
 

--- a/flood_adapt/dbs_classes/dbs_strategy.py
+++ b/flood_adapt/dbs_classes/dbs_strategy.py
@@ -104,26 +104,6 @@ class DbsStrategy(DbsTemplate[Strategy]):
                     counter += 1
             raise ValueError(msg)
 
-    def _check_standard_objects(self, name: str) -> bool:
-        """Check if a strategy is a standard strategy.
-
-        Parameters
-        ----------
-        name : str
-            name of the strategy to be checked
-
-        Raises
-        ------
-        ValueError
-            Raise error if strategy is a standard strategy.
-        """
-        # Check if strategy is a standard strategy
-        if self._database.site.standard_objects:
-            if self._database.site.standard_objects.strategies:
-                if name in self._database.site.standard_objects.strategies:
-                    return True
-        return False
-
     def check_higher_level_usage(self, name: str) -> list[str]:
         """Check if a strategy is used in a scenario.
 

--- a/flood_adapt/dbs_classes/dbs_template.py
+++ b/flood_adapt/dbs_classes/dbs_template.py
@@ -1,7 +1,7 @@
 import shutil
 from datetime import datetime
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, Optional, TypeVar
 
 import tomli
 import tomli_w
@@ -18,12 +18,14 @@ class DbsTemplate(AbstractDatabaseElement[T_OBJECTMODEL]):
     dir_name: str
     _object_class: type[T_OBJECTMODEL]
 
-    def __init__(self, database: IDatabase):
+    def __init__(
+        self, database: IDatabase, standard_objects: Optional[list[str]] = None
+    ):
         """Initialize any necessary attributes."""
         self._database = database
         self.input_path = database.input_path / self.dir_name
         self.output_path = database.output_path / self.dir_name
-        self.standard_objects = []
+        self.standard_objects = standard_objects
 
     def get(self, name: str) -> T_OBJECTMODEL:
         """Return an object of the type of the database with the given name.
@@ -188,8 +190,8 @@ class DbsTemplate(AbstractDatabaseElement[T_OBJECTMODEL]):
         bool
             True if the object is a standard object, False otherwise
         """
-        # If this function is not implemented for the object type, it cannot be a standard object.
-        # By default, it is not a standard object.
+        if self.standard_objects:
+            return name in self.standard_objects
         return False
 
     def check_higher_level_usage(self, name: str) -> list[str]:

--- a/tests/data/create_test_static.py
+++ b/tests/data/create_test_static.py
@@ -42,7 +42,7 @@ from flood_adapt.config.sfincs import (
     SlrScenariosModel,
     WaterlevelReferenceModel,
 )
-from flood_adapt.config.site import Site
+from flood_adapt.config.site import Site, StandardObjectModel
 from flood_adapt.objects.forcing.tide_gauge import (
     TideGauge,
     TideGaugeSource,
@@ -290,6 +290,14 @@ def create_sfincs_config() -> SfincsModel:
     return sfincs
 
 
+def create_standard_objects() -> StandardObjectModel:
+    return StandardObjectModel(
+        events=["test_set"],
+        strategies=["no_measures"],
+        projections=["current"],
+    )
+
+
 def create_site_config(
     database_path: Path,
     fiat: Optional[FiatModel] = None,
@@ -305,6 +313,7 @@ def create_site_config(
         description="Charleston, SC",
         lat=32.7765,
         lon=-79.9311,
+        standard_objects=create_standard_objects(),
         fiat=fiat,
         gui=gui,
         sfincs=sfincs,

--- a/tests/test_dbs_classes/test_database.py
+++ b/tests/test_dbs_classes/test_database.py
@@ -2,6 +2,8 @@ import shutil
 from os import listdir
 from pathlib import Path
 
+import pytest
+
 from flood_adapt.config.config import Settings
 from flood_adapt.config.site import Site
 from flood_adapt.dbs_classes.database import Database
@@ -143,3 +145,26 @@ def test_shutdown_AfterShutdown_CanReadNewDatabase():
     assert dbs._measures is not None
     assert dbs._projections is not None
     assert dbs._benefits is not None
+
+
+def test_cannot_delete_standard_objects(test_db: Database):
+    # Arrange
+
+    # Act
+    for event in test_db.site.standard_objects.events:
+        with pytest.raises(ValueError) as excinfo:
+            test_db.events.delete(event)
+
+        assert "cannot be deleted/modified since it is a standard" in str(excinfo.value)
+
+    for projection in test_db.site.standard_objects.projections:
+        with pytest.raises(ValueError) as excinfo:
+            test_db.projections.delete(projection)
+
+        assert "cannot be deleted/modified since it is a standard" in str(excinfo.value)
+
+    for strategy in test_db.site.standard_objects.strategies:
+        with pytest.raises(ValueError) as excinfo:
+            test_db.strategies.delete(strategy)
+
+        assert "cannot be deleted/modified since it is a standard" in str(excinfo.value)


### PR DESCRIPTION
## Issue addressed
Fixes #778 

## Explanation
Pass standard objects to the `__init__` of DbsTemplate and updated the function `_check_standard_objects` to use them.
Added `create_standard_objects` to the script `create_test_static.py`.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
