### PR TITLE
fix(dbs-controller): Not mandatory configs for return periods and SLR scenarios do not break the initialization

### DIFF
--- a/flood_adapt/config/fiat.py
+++ b/flood_adapt/config/fiat.py
@@ -209,7 +209,7 @@ class FiatModel(BaseModel):
     config: FiatConfigModel
 
     benefits: Optional[BenefitsModel] = None
-    risk: Optional[RiskModel] = None
+    risk: Optional[RiskModel] = RiskModel()
 
     @staticmethod
     def read_toml(path: Path) -> "FiatModel":

--- a/flood_adapt/dbs_classes/dbs_static.py
+++ b/flood_adapt/dbs_classes/dbs_static.py
@@ -48,7 +48,8 @@ class DbsStatic(IDbsStatic):
         self.get_model_boundary()
         self.get_model_grid()
         self.get_obs_points()
-        self.get_slr_scn_names()
+        if self._database.site.sfincs.slr_scenarios is not None:
+            self.get_slr_scn_names()
         self.get_buildings()
         self.get_property_types()
 


### PR DESCRIPTION
## Issue addressed
Makes sure that FloodAdapt still runs when non-mandatory inputs are not provided, for return periods and SLR scenarios.

## Explanation
Default values for risk (which has the return periods) has been udpated from None to the default risk Model, and the method to get the slr scenarios is only run if the file is provided.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
