### PR TITLE
fix(dbs-builder): Correct config for no observation points

### DIFF
--- a/flood_adapt/database_builder/database_builder.py
+++ b/flood_adapt/database_builder/database_builder.py
@@ -1280,9 +1280,9 @@ class DatabaseBuilder:
             relative_to_year=self.config.slr_scenarios.relative_to_year,
         )
 
-    def create_observation_points(self) -> list[ObsPointModel]:
+    def create_observation_points(self) -> Union[list[ObsPointModel], None]:
         if self.config.obs_point is None:
-            return []
+            return None
 
         self.logger.info("Observation points were provided in the config file.")
         return self.config.obs_point


### PR DESCRIPTION
## Issue addressed
When no observations points were provided the config value was set to [], which wrote an empty .obs file that broke hydromt-sfincs

## Explanation
The value for when no observation points are provided, was changed to None, which is handled correctly by the SFINCS adapter.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
