### PR TITLE
fix(object-model): temporarily disable METEO and MODEL forcings

### DIFF
--- a/flood_adapt/objects/events/historical.py
+++ b/flood_adapt/objects/events/historical.py
@@ -34,17 +34,17 @@ class HistoricalEvent(Event):
     ALLOWED_FORCINGS: ClassVar[dict[ForcingType, List[ForcingSource]]] = {
         ForcingType.RAINFALL: [
             ForcingSource.CSV,
-            ForcingSource.METEO,
+            # ForcingSource.METEO, # Temporarily excluded due to bug in hydromt-sfincs. fixed in v1.3.0
             ForcingSource.SYNTHETIC,
             ForcingSource.CONSTANT,
         ],
         ForcingType.WIND: [
             ForcingSource.CSV,
-            ForcingSource.METEO,
+            # ForcingSource.METEO, # Temporarily excluded due to bug in hydromt-sfincs. fixed in v1.3.0
             ForcingSource.CONSTANT,
         ],
         ForcingType.WATERLEVEL: [
-            ForcingSource.MODEL,
+            # ForcingSource.MODEL, # Temporarily excluded due to the METEO bug in hydromt-sfincs. fixed in v1.3.0
             ForcingSource.CSV,
             ForcingSource.SYNTHETIC,
             ForcingSource.GAUGED,

--- a/flood_adapt/objects/events/hurricane.py
+++ b/flood_adapt/objects/events/hurricane.py
@@ -53,7 +53,7 @@ class HurricaneEvent(Event):
             ForcingSource.CSV,
             ForcingSource.SYNTHETIC,
             ForcingSource.TRACK,
-            ForcingSource.METEO,
+            # ForcingSource.METEO, # Temporarily excluded due to bug in hydromt-sfincs. fixed in v1.3.0
         ],
         ForcingType.WIND: [ForcingSource.TRACK],
         ForcingType.WATERLEVEL: [ForcingSource.MODEL],

--- a/tests/data/create_test_input.py
+++ b/tests/data/create_test_input.py
@@ -33,7 +33,6 @@ from flood_adapt.objects.forcing.discharge import (
 from flood_adapt.objects.forcing.forcing import ForcingType
 from flood_adapt.objects.forcing.rainfall import (
     RainfallConstant,
-    RainfallMeteo,
     RainfallTrack,
 )
 from flood_adapt.objects.forcing.time_frame import TimeFrame
@@ -50,7 +49,6 @@ from flood_adapt.objects.forcing.waterlevels import (
 )
 from flood_adapt.objects.forcing.wind import (
     WindConstant,
-    WindMeteo,
     WindTrack,
 )
 from flood_adapt.objects.measures.measures import (
@@ -708,9 +706,35 @@ def _create_single_events():
                     ),
                 ),
             ],
-            ForcingType.RAINFALL: [RainfallMeteo()],
-            ForcingType.WIND: [WindMeteo()],
-            ForcingType.WATERLEVEL: [WaterlevelModel()],
+            # ForcingType.RAINFALL: [RainfallMeteo()],      # Temporarily excluded due to bug in hydromt-sfincs. fixed in v1.3.0
+            # ForcingType.WIND: [WindMeteo()],              # Temporarily excluded due to bug in hydromt-sfincs. fixed in v1.3.0
+            # ForcingType.WATERLEVEL: [WaterlevelModel()],  # Temporarily excluded due to bug in hydromt-sfincs. fixed in v1.3.0
+            ForcingType.WATERLEVEL: [
+                WaterlevelSynthetic(
+                    surge=SurgeModel(
+                        timeseries=TimeseriesFactory.from_args(
+                            shape_type=ShapeType.triangle,
+                            duration=us.UnitfulTime(
+                                value=1, units=us.UnitTypesTime.days
+                            ),
+                            peak_time=us.UnitfulTime(
+                                value=8, units=us.UnitTypesTime.hours
+                            ),
+                            peak_value=us.UnitfulLength(
+                                value=1, units=us.UnitTypesLength.meters
+                            ),
+                        )
+                    ),
+                    tide=TideModel(
+                        harmonic_amplitude=us.UnitfulLength(
+                            value=1, units=us.UnitTypesLength.meters
+                        ),
+                        harmonic_phase=us.UnitfulTime(
+                            value=0, units=us.UnitTypesTime.hours
+                        ),
+                    ),
+                )
+            ],
         },
     )
     return EXTREME_12FT, EXTREME_12FT_RIVERSHAPE_WINDCONST, FLORENCE, KINGTIDE_NOV2021

--- a/tests/test_flood_adapt.py
+++ b/tests/test_flood_adapt.py
@@ -357,6 +357,9 @@ class TestScenarios:
         )
         return test_fa, scn, test_eventset
 
+    @pytest.mark.skip(
+        reason="Skipped until METEO forcing is fixed in hydromt-sfincs 1.3.0",
+    )
     def test_run_offshore_scenario(
         self, test_fa: FloodAdapt, setup_offshore_meteo_scenario
     ):
@@ -403,6 +406,9 @@ class TestScenarios:
 
         assert finished_file_exists(test_fa.database.scenarios.output_path / scn.name)
 
+    @pytest.mark.skip(
+        reason="Skipped until METEO forcing is fixed in hydromt-sfincs 1.3.0",
+    )
     def test_create_save_scenario(
         self, test_fa: FloodAdapt, setup_offshore_meteo_event
     ):

--- a/tests/test_objects/test_events/test_eventset.py
+++ b/tests/test_objects/test_events/test_eventset.py
@@ -115,7 +115,7 @@ def test_sub_event() -> SyntheticEvent:
 def test_eventset(
     test_sub_event: SyntheticEvent,
     setup_nearshore_event: HistoricalEvent,
-    setup_offshore_meteo_event: HistoricalEvent,
+    # setup_offshore_meteo_event: HistoricalEvent, # uncomment when hydromt-sfincs 1.3.0 is released
 ) -> EventSet:
     sub_event_models: list[SubEventModel] = []
     sub_events = []
@@ -123,10 +123,14 @@ def test_eventset(
     hurricane = _create_hurricane_event("sub_hurricane")
     synthetic = test_sub_event
     historical_nearshore = setup_nearshore_event
-    historical_offshore = setup_offshore_meteo_event
+    # historical_offshore = setup_offshore_meteo_event # uncomment when hydromt-sfincs 1.3.0 is released
 
     for i, event in enumerate(
-        [hurricane, synthetic, historical_nearshore, historical_offshore]
+        [
+            hurricane,
+            synthetic,
+            historical_nearshore,
+        ]  # , historical_offshore] # uncomment when hydromt-sfincs 1.3.0 is released
     ):
         event.name = f"{event.name}_{i + 1:04d}"
         sub_event_models.append(SubEventModel(name=event.name, frequency=i + 1))

--- a/tests/test_objects/test_events/test_historical.py
+++ b/tests/test_objects/test_events/test_historical.py
@@ -138,10 +138,10 @@ def setup_offshore_scenario(
 
 class TestHistoricalEvent:
     def test_save_event_toml(
-        self, setup_offshore_meteo_event: HistoricalEvent, tmp_path: Path
+        self, setup_nearshore_event: HistoricalEvent, tmp_path: Path
     ):
         path = tmp_path / "test_event.toml"
-        event = setup_offshore_meteo_event
+        event = setup_nearshore_event
         event.save(path)
         assert path.exists()
 
@@ -162,11 +162,9 @@ class TestHistoricalEvent:
         # Assert
         assert all(csv.exists() for csv in expected_csvs)
 
-    def test_load_file(
-        self, setup_offshore_meteo_event: HistoricalEvent, tmp_path: Path
-    ):
+    def test_load_file(self, setup_nearshore_event: HistoricalEvent, tmp_path: Path):
         path = tmp_path / "test_event.toml"
-        saved_event = setup_offshore_meteo_event
+        saved_event = setup_nearshore_event
         saved_event.save(path)
         assert path.exists()
 

--- a/tests/test_objects/test_events/test_offshore.py
+++ b/tests/test_objects/test_events/test_offshore.py
@@ -77,6 +77,9 @@ def setup_offshore_scenario(test_db: IDatabase):
     reason="Skipped on Linux due to broken sfincs binary",
 )
 class TestOffshoreSfincsHandler:
+    @pytest.mark.skip(
+        reason="Skipped until METEO forcing is fixed in hydromt-sfincs 1.3.0",
+    )
     def test_process_sfincs_offshore(
         self,
         setup_offshore_scenario: tuple[IDatabase, Scenario, HistoricalEvent],

--- a/tests/test_objects/test_forcing/test_waterlevels.py
+++ b/tests/test_objects/test_forcing/test_waterlevels.py
@@ -189,37 +189,35 @@ class TestWaterlevelModel:
     @pytest.fixture()
     def setup_offshore_scenario(self, test_db: IDatabase):
         event = HistoricalEvent(
-            HistoricalEvent(
-                name="test_historical_offshore_meteo",
-                time=TimeFrame(),
-                forcings={
-                    ForcingType.WATERLEVEL: [
-                        WaterlevelModel(),
-                    ],
-                    ForcingType.WIND: [
-                        WindMeteo(),
-                    ],
-                    ForcingType.RAINFALL: [
-                        RainfallMeteo(),
-                    ],
-                    ForcingType.DISCHARGE: [
-                        DischargeConstant(
-                            river=RiverModel(
-                                name="cooper",
-                                description="Cooper River",
-                                x_coordinate=595546.3,
-                                y_coordinate=3675590.6,
-                                mean_discharge=us.UnitfulDischarge(
-                                    value=5000, units=us.UnitTypesDischarge.cfs
-                                ),
-                            ),
-                            discharge=us.UnitfulDischarge(
+            name="test_historical_offshore_meteo",
+            time=TimeFrame(),
+            forcings={
+                ForcingType.WATERLEVEL: [
+                    WaterlevelModel(),
+                ],
+                ForcingType.WIND: [
+                    WindMeteo(),
+                ],
+                ForcingType.RAINFALL: [
+                    RainfallMeteo(),
+                ],
+                ForcingType.DISCHARGE: [
+                    DischargeConstant(
+                        river=RiverModel(
+                            name="cooper",
+                            description="Cooper River",
+                            x_coordinate=595546.3,
+                            y_coordinate=3675590.6,
+                            mean_discharge=us.UnitfulDischarge(
                                 value=5000, units=us.UnitTypesDischarge.cfs
                             ),
                         ),
-                    ],
-                },
-            )
+                        discharge=us.UnitfulDischarge(
+                            value=5000, units=us.UnitTypesDischarge.cfs
+                        ),
+                    ),
+                ],
+            },
         )
 
         test_db.events.save(event)


### PR DESCRIPTION
## Issue addressed
Fixes #823

## Explanation
due to a bug in how hydromtsfincs handles METEO data, we cannot run the offshore modcel for historical events.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
