### PR TITLE
refactor(dbs-builder): Update how dbs builder gets default water level references

### DIFF
--- a/tests/test_database_builder/test_database_builder.py
+++ b/tests/test_database_builder/test_database_builder.py
@@ -741,7 +741,15 @@ class TestDataBaseBuilder:
             max_distance=us.UnitfulLength(value=100, units=us.UnitTypesLength.miles),
         )
         builder = DatabaseBuilder(mock_config)
-
+        builder.water_level_references = WaterlevelReferenceModel(
+            reference="MSL",
+            datums=[
+                DatumModel(
+                    name="MSL",
+                    height=us.UnitfulLength(value=0, units=us.UnitTypesLength.meters),
+                )
+            ],
+        )
         # Act
         tide_gauge = builder.create_tide_gauge()
 
@@ -775,6 +783,15 @@ class TestDataBaseBuilder:
         )
 
         builder = DatabaseBuilder(mock_config)
+        builder.water_level_references = WaterlevelReferenceModel(
+            reference="MSL",
+            datums=[
+                DatumModel(
+                    name="MSL",
+                    height=us.UnitfulLength(value=0, units=us.UnitTypesLength.meters),
+                )
+            ],
+        )
 
         # Act
         with pytest.raises(ValueError) as excinfo:
@@ -805,6 +822,15 @@ class TestDataBaseBuilder:
             max_distance=us.UnitfulLength(value=100, units=us.UnitTypesLength.miles),
         )
         builder = DatabaseBuilder(mock_config)
+        builder.water_level_references = WaterlevelReferenceModel(
+            reference="MSL",
+            datums=[
+                DatumModel(
+                    name="MSL",
+                    height=us.UnitfulLength(value=0, units=us.UnitTypesLength.meters),
+                )
+            ],
+        )
 
         # Act
         tide_gauge = builder.create_tide_gauge()
@@ -822,7 +848,8 @@ class TestDataBaseBuilder:
             location=Point(lat=32.78, lon=-79.9233),
             max_distance=us.UnitfulLength(value=100, units=us.UnitTypesLength.miles),
         )
-        mock_config.references = WaterlevelReferenceModel(
+        builder = DatabaseBuilder(mock_config)
+        builder.water_level_references = WaterlevelReferenceModel(
             reference="MSL",
             datums=[
                 DatumModel(
@@ -831,8 +858,6 @@ class TestDataBaseBuilder:
                 )
             ],
         )
-        builder = DatabaseBuilder(mock_config)
-
         # Act
         tide_gauge = builder.create_tide_gauge()
         datum_names = [datum.name for datum in builder.water_level_references.datums]


### PR DESCRIPTION
## Issue addressed
The default references in the config is a having the "MSL" set to 0. But we need to always provide a reference for the overland SFINCS model. If this is not "MSL", the user needs to know that they have to add the datum in the references list. 

## Explanation
Now, the user only needs to provide a name for the reference of the SFINCS model. Then if the user does not provide manualy a water level reference obejct, the SFINCS ref name will be used as the main reference in the water level references object, and assumed=0. 

Then the standard updates if a NOAA station is used, will take place

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
