### PR TITLE
fix(adapter): Tide gauge was assmumed to always be there during obs point html creation

### DIFF
--- a/flood_adapt/adapter/sfincs_adapter.py
+++ b/flood_adapt/adapter/sfincs_adapter.py
@@ -675,7 +675,10 @@ class SfincsAdapter(IHazardAdapter):
             )
 
             event = self.database.events.get(scenario.event)
-            if self.settings.obs_point[ii].name == self.settings.tide_gauge.name:
+            if (
+                self.settings.tide_gauge is not None
+                and self.settings.obs_point[ii].name == self.settings.tide_gauge.name
+            ):
                 self._add_tide_gauge_plot(fig, event, units=gui_units)
 
             # write html to results folder


### PR DESCRIPTION
fixed issue when tide gauge was not available and observation was plotted

## Issue addressed
Fixes #<issue number>

## Explanation
Explain how you addressed the bug/feature request, what choices you made and why.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
