### PR TITLE
fix(dbs-controller): Remove caching of models and check for scenario run instead of hazard run

### DIFF
--- a/flood_adapt/dbs_classes/dbs_static.py
+++ b/flood_adapt/dbs_classes/dbs_static.py
@@ -227,7 +227,6 @@ class DbsStatic(IDbsStatic):
         """
         return self.get_fiat_model().get_property_types()
 
-    @cache_method_wrapper
     def get_hazard_models(self) -> list[IHazardAdapter]:
         """Get the hazard models from the database.
 
@@ -238,7 +237,6 @@ class DbsStatic(IDbsStatic):
         """
         return [self.get_overland_sfincs_model()]
 
-    @cache_method_wrapper
     def get_impact_models(self) -> list[IImpactAdapter]:
         """Get the impact models from the database.
 
@@ -249,7 +247,6 @@ class DbsStatic(IDbsStatic):
         """
         return [self.get_fiat_model()]
 
-    @cache_method_wrapper
     def get_overland_sfincs_model(self) -> SfincsAdapter:
         """Get the template offshore SFINCS model."""
         overland_path = (
@@ -260,7 +257,6 @@ class DbsStatic(IDbsStatic):
         with SfincsAdapter(model_root=overland_path) as overland_model:
             return overland_model
 
-    @cache_method_wrapper
     def get_offshore_sfincs_model(self) -> SfincsAdapter:
         """Get the template overland Sfincs model."""
         if self._database.site.sfincs.config.offshore_model is None:
@@ -274,7 +270,6 @@ class DbsStatic(IDbsStatic):
         with SfincsAdapter(model_root=offshore_path) as offshore_model:
             return offshore_model
 
-    @cache_method_wrapper
     def get_fiat_model(self) -> FiatAdapter:
         """Get the path to the FIAT model."""
         if self._database.site.fiat is None:

--- a/flood_adapt/flood_adapt.py
+++ b/flood_adapt/flood_adapt.py
@@ -883,7 +883,7 @@ class FloodAdapt:
         scenario = self.database.scenarios.get(name)
 
         # Check if the scenario has run
-        if not ScenarioRunner(self.database, scenario=scenario).hazard_run_check():
+        if not ScenarioRunner(self.database, scenario=scenario).has_run_check():
             logger.info(
                 f"Cannot retrieve observation point timeseries as the scenario {name} has not been run yet."
             )


### PR DESCRIPTION
## Issue addressed
During one of the last iterations, the models in the dbs_static class were cached. This created issues during initializations of the database class. 

This was done to speed up some calls in the gui. This was now acchieved by using the scenario.has_run method instead of the scenario.hazard_run_check method which is a lot slower.

If the scenario is run, by definition the hazard has been run.

## Explanation
Explain how you addressed the bug/feature request, what choices you made and why.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
