### PR TITLE
refactor(object-model): Make sure the SFINCS datum is not always plotted in the water level graphs

### DIFF
--- a/flood_adapt/objects/forcing/plotting.py
+++ b/flood_adapt/objects/forcing/plotting.py
@@ -228,21 +228,9 @@ def plot_waterlevel(
     # Plot actual thing
     fig = px.line(data)
 
-    # plot main reference
-    fig.add_hline(
-        y=0,
-        line_dash="dash",
-        line_color="#000000",
-        annotation_text=site.sfincs.water_level.reference,
-        annotation_position="bottom right",
-    )
-
     # plot other references
     for wl_ref in site.sfincs.water_level.datums:
-        if (
-            wl_ref.name == site.sfincs.config.overland_model.reference
-            or wl_ref.name in site.gui.plotting.excluded_datums
-        ):
+        if wl_ref.name in site.gui.plotting.excluded_datums:
             continue
 
         fig.add_hline(


### PR DESCRIPTION
## Issue addressed
Fixes #916

## Explanation
Made sure that the SFINCS datum is not forced to be plotted in the water level graphs. All the datums in the water_levels attribute that are not in the exclude_datums list will be plotted now.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
