### PR TITLE
Write mutated objects to tmp_dir before deleting

### DIFF
--- a/docs/clean_database.py
+++ b/docs/clean_database.py
@@ -28,7 +28,8 @@ def clean_database(database_dir: Path):
             print(f"Removed directory: {dir_path}")
 
     # Validate
-    Settings(DATABASE_ROOT=database_dir.parent, DATABASE_NAME=database_dir.name)
+    s = Settings(DATABASE_ROOT=database_dir.parent, DATABASE_NAME=database_dir.name)
+    s.export_to_env()
     FloodAdapt(database_dir)
 
 if __name__ == "__main__":

--- a/flood_adapt/database_builder/database_builder.py
+++ b/flood_adapt/database_builder/database_builder.py
@@ -639,14 +639,14 @@ class DatabaseBuilder:
                 name=self._no_measures_strategy_name,
                 measures=[],
             )
-            db.strategies.save(strategy)
+            db.strategies.add(strategy)
             # Create current projection
             projection = Projection(
                 name=self._current_projection_name,
                 physical_projection=PhysicalProjection(),
                 socio_economic_change=SocioEconomicChange(),
             )
-            db.projections.save(projection)
+            db.projections.add(projection)
             # Check prob set
             if self._probabilistic_set_name is not None:
                 path_toml = (
@@ -661,6 +661,7 @@ class DatabaseBuilder:
                     raise ValueError(
                         f"Provided probabilistic event set '{self._probabilistic_set_name}' is not valid. Error: {e}"
                     )
+            db.flush()
 
     ### TEMPLATE READERS ###
     @debug_timer

--- a/flood_adapt/dbs_classes/database.py
+++ b/flood_adapt/dbs_classes/database.py
@@ -23,9 +23,11 @@ from flood_adapt.dbs_classes.dbs_scenario import DbsScenario
 from flood_adapt.dbs_classes.dbs_static import DbsStatic
 from flood_adapt.dbs_classes.dbs_strategy import DbsStrategy
 from flood_adapt.dbs_classes.interface.database import IDatabase
+from flood_adapt.dbs_classes.interface.element import AbstractDatabaseElement
 from flood_adapt.misc.exceptions import ConfigError, DatabaseError
 from flood_adapt.misc.log import FloodAdaptLogging
 from flood_adapt.misc.utils import finished_file_exists
+from flood_adapt.objects.events.event_set import EventSet
 from flood_adapt.objects.events.events import Mode
 from flood_adapt.objects.forcing import unit_system as us
 from flood_adapt.objects.output.floodmap import FloodMap
@@ -116,6 +118,10 @@ class Database(IDatabase):
         # Read site configuration
         self.read_site()
 
+        # Initialize the different database objects
+        self._initialize_repositories()
+        self.load()
+
         # Delete any unfinished/crashed scenario output after initialization
         self._init_done = True
         self.cleanup()
@@ -129,7 +135,8 @@ class Database(IDatabase):
             )
         self.site = Site.load_file(site_path)
 
-        # Initialize the different database objects
+    def _initialize_repositories(self):
+        """Initialize object repositories and store them in `self._repositories`."""
         self.static = DbsStatic(self)
         self.events = DbsEvent(self, standard_objects=self.site.standard_objects.events)
         self.scenarios = DbsScenario(self)
@@ -141,6 +148,26 @@ class Database(IDatabase):
             self, standard_objects=self.site.standard_objects.projections
         )
         self.benefits = DbsBenefit(self)
+        self._repositories: list[AbstractDatabaseElement] = [
+            self.events,
+            self.projections,
+            self.measures,
+            self.strategies,
+            self.scenarios,
+            self.benefits,
+        ]
+
+    def load(self):
+        """Load all repositories from disk into memory."""
+        logger.info("Loading database into memory")
+        for repo in self._repositories:
+            repo.load()
+
+    def flush(self):
+        """Write all repository changes from memory to disk."""
+        logger.info("Writing database changes to disk")
+        for repo in self._repositories:
+            repo.flush()
 
     def shutdown(self):
         """Explicitly shut down the singleton and clear all references."""
@@ -587,8 +614,12 @@ class Database(IDatabase):
             Name of the scenario to delete simulations for.
         """
         scn = self.scenarios.get(scenario_name)
-        event = self.events.get(scn.event, load_all=True)
-        sub_events = event._events if event.mode == Mode.risk else None
+        event = self.events.get(scn.event)
+        if isinstance(event, EventSet):
+            event = self.events.get_event_set(scn.event)
+            sub_events = event._events
+        else:
+            sub_events = None
 
         if not self.site.sfincs.config.save_simulation:
             # Delete SFINCS overland

--- a/flood_adapt/dbs_classes/dbs_benefit.py
+++ b/flood_adapt/dbs_classes/dbs_benefit.py
@@ -9,31 +9,9 @@ class DbsBenefit(DbsTemplate[Benefit]):
     _object_class = Benefit
     _higher_lvl_object = ""
 
-    def save(self, object_model: Benefit, overwrite: bool = False):
-        """Save a benefit object in the database.
-
-        Parameters
-        ----------
-        object_model : Benefit
-            object of Benefit type
-        overwrite : bool, optional
-            whether to overwrite existing benefit with same name, by default False
-
-        Raises
-        ------
-        DatabaseError
-            Raise error if name is already in use. Names of benefits assessments should be unique.
-        """
-        runner = BenefitRunner(self._database, benefit=object_model)
-
-        # Check if all scenarios are created
-        if not all(runner.scenarios["scenario created"] != "No"):
-            raise DatabaseError(
-                f"'{object_model.name}' name cannot be created before all necessary scenarios are created."
-            )
-
-        # Save the benefit
-        super().save(object_model, overwrite=overwrite)
+    def add(self, obj: Benefit, overwrite: bool = False):
+        self._assert_all_scenarios_created(obj)
+        super().add(obj, overwrite=overwrite)
 
     def get_runner(self, name: str) -> BenefitRunner:
         return BenefitRunner(self._database, self.get(name))
@@ -50,3 +28,12 @@ class DbsBenefit(DbsTemplate[Benefit]):
             True if required scenarios have been already run
         """
         return self.get_runner(name).ready_to_run()
+
+    def _assert_all_scenarios_created(self, benefit: Benefit):
+        runner = BenefitRunner(self._database, benefit=benefit)
+
+        # Check if all scenarios are created
+        if not all(runner.scenarios["scenario created"] != "No"):
+            raise DatabaseError(
+                f"'{benefit.name}' name cannot be created before all necessary scenarios are created."
+            )

--- a/flood_adapt/dbs_classes/dbs_event.py
+++ b/flood_adapt/dbs_classes/dbs_event.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from flood_adapt.dbs_classes.dbs_template import DbsTemplate
-from flood_adapt.misc.exceptions import DoesNotExistError
+from flood_adapt.misc.exceptions import DatabaseError
 from flood_adapt.objects.events.event_factory import EventFactory
 from flood_adapt.objects.events.event_set import EventSet
 from flood_adapt.objects.events.events import Event
@@ -13,30 +13,19 @@ class DbsEvent(DbsTemplate[Event]):
     _object_class = Event
     _higher_lvl_object = "Scenario"
 
-    def get(self, name: str, load_all: bool = False) -> Event | EventSet:
-        """Return an event object.
+    def _read_object(self, path: Path) -> Event:
+        return EventFactory.load_file(path)
 
-        Parameters
-        ----------
-        name : str
-            name of the event to be returned
+    def get_event_set(self, name: str) -> EventSet:
+        """Get the event set that the event belongs to."""
+        event_set = self.get(name)
+        if not isinstance(event_set, EventSet):
+            raise DatabaseError(f"Event {name} is not an event set.")
+        path = self._object_path(self.input_path, event_set.name)
+        event_set.load_sub_events(file_path=path)
+        return event_set
 
-        Returns
-        -------
-        Event
-            event object
-        """
-        # Get event path
-        event_path = self.input_path / f"{name}" / f"{name}.toml"
-
-        # Check if the object exists
-        if not Path(event_path).is_file():
-            raise DoesNotExistError(name, self.display_name)
-
-        # Load event
-        return EventFactory.load_file(event_path, load_all=load_all)
-
-    def check_higher_level_usage(self, name: str) -> list[str]:
+    def used_by_higher_level(self, name: str) -> list[str]:
         """Check if an event is used in a scenario.
 
         Parameters
@@ -50,10 +39,7 @@ class DbsEvent(DbsTemplate[Event]):
             list of scenarios that use the event
         """
         # Get all the scenarios
-        scenarios = [
-            self._database.scenarios.get(scn)
-            for scn in self._database.scenarios.summarize_objects()["name"]
-        ]
+        scenarios = self._database.scenarios.list_all()
 
         # Check if event is used in a scenario
         used_in_scenario = [

--- a/flood_adapt/dbs_classes/dbs_event.py
+++ b/flood_adapt/dbs_classes/dbs_event.py
@@ -21,7 +21,7 @@ class DbsEvent(DbsTemplate[Event]):
         event_set = self.get(name)
         if not isinstance(event_set, EventSet):
             raise DatabaseError(f"Event {name} is not an event set.")
-        path = self._object_path(self.input_path, event_set.name)
+        path = self.input_path / event_set.name / f"{event_set.name}.toml"
         event_set.load_sub_events(file_path=path)
         return event_set
 

--- a/flood_adapt/dbs_classes/dbs_measure.py
+++ b/flood_adapt/dbs_classes/dbs_measure.py
@@ -1,11 +1,7 @@
 from pathlib import Path
 from typing import Any
 
-import geopandas as gpd
-
 from flood_adapt.dbs_classes.dbs_template import DbsTemplate
-from flood_adapt.misc.exceptions import DatabaseError, DoesNotExistError
-from flood_adapt.misc.utils import resolve_filepath
 from flood_adapt.objects.measures.measure_factory import MeasureFactory
 from flood_adapt.objects.measures.measures import Measure
 
@@ -16,28 +12,8 @@ class DbsMeasure(DbsTemplate[Measure]):
     _object_class = Measure
     _higher_lvl_object = "Strategy"
 
-    def get(self, name: str) -> Measure:
-        """Return a measure object.
-
-        Parameters
-        ----------
-        name : str
-            name of the measure to be returned
-
-        Returns
-        -------
-        Measure
-            measure object
-        """
-        # Make the full path to the object
-        full_path = self.input_path / name / f"{name}.toml"
-
-        # Check if the object exists
-        if not Path(full_path).is_file():
-            raise DoesNotExistError(name, self.display_name)
-
-        # Load and return the object
-        return MeasureFactory.get_measure_object(full_path)
+    def _read_object(self, path: Path):
+        return MeasureFactory.get_measure_object(path)
 
     def summarize_objects(self) -> dict[str, list[Any]]:
         """Return a dictionary with info on the measures that currently exist in the database.
@@ -47,44 +23,25 @@ class DbsMeasure(DbsTemplate[Measure]):
         dict[str, Any]
             Includes 'name', 'description', 'path' and 'last_modification_date' and 'geometry' info
         """
-        measures = self._get_object_summary()
-        objects = [self.get(name) for name in measures["name"]]
+        measures = super().summarize_objects()
+        objects = self.list_all()
 
         geometries = []
         for obj in objects:
-            # If polygon is used read the polygon file
-            if hasattr(obj, "polygon_file") and obj.polygon_file:
-                src_path = resolve_filepath(
-                    object_dir=self.dir_name,
-                    obj_name=obj.name,
-                    path=obj.polygon_file,
+            if obj.polygon_file:
+                geom = obj.read_gdf()
+            elif obj.aggregation_area_name and obj.aggregation_area_type:
+                geom = self._database.static.get_aggregation_area_by_type_and_name(
+                    obj.aggregation_area_type, obj.aggregation_area_name
                 )
-                geometries.append(gpd.read_file(src_path))
-            # If aggregation area is used read the polygon from the aggregation area name
-            elif hasattr(obj, "aggregation_area_name") and obj.aggregation_area_name:
-                if (
-                    obj.aggregation_area_type
-                    not in self._database.static.get_aggregation_areas()
-                ):
-                    raise DatabaseError(
-                        f"Aggregation area type {obj.aggregation_area_type} for measure {obj.name} does not exist."
-                    )
-                gdf = self._database.static.get_aggregation_areas()[
-                    obj.aggregation_area_type
-                ]
-                if obj.aggregation_area_name not in gdf["name"].to_numpy():
-                    raise DatabaseError(
-                        f"Aggregation area name {obj.aggregation_area_name} for measure {obj.name} does not exist."
-                    )
-                geometries.append(gdf.loc[gdf["name"] == obj.aggregation_area_name, :])
-            # Else assign a None value
             else:
-                geometries.append(None)
+                geom = None
+            geometries.append(geom)
 
         measures["geometry"] = geometries
         return measures
 
-    def check_higher_level_usage(self, name: str) -> list[str]:
+    def used_by_higher_level(self, name: str) -> list[str]:
         """Check if a measure is used in a strategy.
 
         Parameters
@@ -98,10 +55,7 @@ class DbsMeasure(DbsTemplate[Measure]):
             list of strategies that use the measure
         """
         # Get all the strategies
-        strategies = [
-            self._database.strategies.get(strategy)
-            for strategy in self._database.strategies.summarize_objects()["name"]
-        ]
+        strategies = self._database.strategies.list_all()
 
         # Check if measure is used in a strategy
         used_in_strategy = [

--- a/flood_adapt/dbs_classes/dbs_projection.py
+++ b/flood_adapt/dbs_classes/dbs_projection.py
@@ -8,7 +8,7 @@ class DbsProjection(DbsTemplate[Projection]):
     _object_class = Projection
     _higher_lvl_object = "Scenario"
 
-    def check_higher_level_usage(self, name: str) -> list[str]:
+    def used_by_higher_level(self, name: str) -> list[str]:
         """Check if a projection is used in a scenario.
 
         Parameters
@@ -22,10 +22,7 @@ class DbsProjection(DbsTemplate[Projection]):
             list of scenarios that use the projection
         """
         # Get all the scenarios
-        scenarios = [
-            self._database.scenarios.get(scn)
-            for scn in self._database.scenarios.summarize_objects()["name"]
-        ]
+        scenarios = self._database.scenarios.list_all()
 
         # Check if projection is used in a scenario
         used_in_scenario = [

--- a/flood_adapt/dbs_classes/dbs_scenario.py
+++ b/flood_adapt/dbs_classes/dbs_scenario.py
@@ -22,21 +22,15 @@ class DbsScenario(DbsTemplate[Scenario]):
             Includes 'name', 'description', 'path' and 'last_modification_date' info
         """
         scenarios = super().summarize_objects()
-        scenarios["Projection"] = [
-            self._read_variable_in_toml("projection", path)
-            for path in scenarios["path"]
-        ]
-        scenarios["Event"] = [
-            self._read_variable_in_toml("event", path) for path in scenarios["path"]
-        ]
-        scenarios["Strategy"] = [
-            self._read_variable_in_toml("strategy", path) for path in scenarios["path"]
-        ]
-        scenarios["finished"] = [self.has_run_check(scn) for scn in scenarios["name"]]
+
+        scenarios["Projection"] = [obj.projection for obj in self._objects.values()]
+        scenarios["Event"] = [obj.event for obj in self._objects.values()]
+        scenarios["Strategy"] = [obj.strategy for obj in self._objects.values()]
+        scenarios["finished"] = [self.has_run_check(scn) for scn in self._objects]
 
         return scenarios
 
-    def check_higher_level_usage(self, name: str) -> list[str]:
+    def used_by_higher_level(self, name: str) -> list[str]:
         """Check if a scenario is used in a benefit.
 
         Parameters
@@ -49,10 +43,7 @@ class DbsScenario(DbsTemplate[Scenario]):
             list[str]
                 list of benefits that use the scenario
         """
-        benefits = [
-            self._database.benefits.get(benefit)
-            for benefit in self._database.benefits.summarize_objects()["name"]
-        ]
+        benefits = self._database.benefits.list_all()
         used_in_benefit = []
         for benefit in benefits:
             runner = BenefitRunner(database=self._database, benefit=benefit)

--- a/flood_adapt/dbs_classes/dbs_static.py
+++ b/flood_adapt/dbs_classes/dbs_static.py
@@ -84,6 +84,22 @@ class DbsStatic(IDbsStatic):
         return aggregation_areas
 
     @cache_method_wrapper
+    def get_aggregation_area_by_type_and_name(
+        self, area_type: str, area_name: str
+    ) -> gpd.GeoDataFrame:
+        areas = self.get_aggregation_areas()
+        if area_type not in areas:
+            raise DatabaseError(
+                f"Aggregation area type {area_type} for measure {area_name} does not exist."
+            )
+        gdf = areas[area_type]
+        if area_name not in gdf["name"].to_numpy():
+            raise DatabaseError(
+                f"Aggregation area name {area_name} for measure {area_type} does not exist."
+            )
+        return gdf.loc[gdf["name"] == area_name, :]
+
+    @cache_method_wrapper
     def get_model_boundary(self) -> gpd.GeoDataFrame:
         """Get the model boundary from the SFINCS model."""
         bnd = self.get_overland_sfincs_model().get_model_boundary()

--- a/flood_adapt/dbs_classes/dbs_template.py
+++ b/flood_adapt/dbs_classes/dbs_template.py
@@ -2,6 +2,7 @@ import logging
 import shutil
 from datetime import datetime
 from pathlib import Path
+from tempfile import gettempdir
 from typing import Any, Optional, TypeVar
 
 from flood_adapt.dbs_classes.interface.database import IDatabase
@@ -73,7 +74,19 @@ class DbsTemplate(AbstractDatabaseElement[T_OBJECTMODEL]):
 
         for name in self._mutated:
             obj = self._objects[name]
-            path = self._object_path(self.input_path, name)
+            path = self.input_path / name / f"{name}.toml"
+
+            # To avoid issues with editing objects, we first write the new version to a temporary dir,
+            # then delete the old dir, and finally move the new dir to the correct location.
+            # This way, the old version is not deleted until the new version is successfully written,
+            # and additional files can be copied from the old version to the new version,
+            # before the old version is deleted.
+            tmp_path = (
+                Path(gettempdir())
+                / f"{name}_{datetime.now().timestamp()}"
+                / f"{name}.toml"
+            )
+            self._write_object(obj, tmp_path)
 
             try:
                 if path.parent.exists():
@@ -91,10 +104,15 @@ class DbsTemplate(AbstractDatabaseElement[T_OBJECTMODEL]):
                     f"Failed to delete output for `{name}` due to: {e}"
                 ) from e
 
-            self._write_object(obj, path)
+            try:
+                shutil.move(tmp_path.parent, path.parent)
+            except OSError as e:
+                raise DatabaseError(
+                    f"Failed to move temporary file for `{name}` due to: {e}"
+                ) from e
+
             self._last_modified[name] = datetime.now()
 
-        # remove deleted
         for name in self._deleted:
             try:
                 if (self.input_path / name).exists():
@@ -248,7 +266,7 @@ class DbsTemplate(AbstractDatabaseElement[T_OBJECTMODEL]):
             Each key has a list of the corresponding values, where the index of the values corresponds to the same object.
         """
         names = list(self._objects)
-        paths = [self._object_path(self.input_path, name) for name in names]
+        paths = [self.input_path / name / f"{name}.toml" for name in names]
         descriptions = [obj.description for obj in self._objects.values()]
         last_modification_date = [self._last_modified.get(name) for name in names]
         objects = {
@@ -270,10 +288,6 @@ class DbsTemplate(AbstractDatabaseElement[T_OBJECTMODEL]):
         obj.save(path)
 
     # Helpers
-    def _object_path(self, base: Path, name: str):
-        """Get the path to the toml file of an object with a given name."""
-        return base / name / f"{name}.toml"
-
     def _is_standard_object(self, name: str) -> bool:
         """Check if an object is a standard object.
 

--- a/flood_adapt/dbs_classes/dbs_template.py
+++ b/flood_adapt/dbs_classes/dbs_template.py
@@ -1,3 +1,4 @@
+import logging
 import shutil
 from datetime import datetime
 from pathlib import Path
@@ -12,10 +13,10 @@ from flood_adapt.misc.exceptions import (
     IsStandardObjectError,
     IsUsedInError,
 )
-from flood_adapt.misc.io import read_toml, write_toml
 from flood_adapt.objects.object_model import Object
 
 T_OBJECTMODEL = TypeVar("T_OBJECTMODEL", bound=Object)
+logger = logging.getLogger(__name__)
 
 
 class DbsTemplate(AbstractDatabaseElement[T_OBJECTMODEL]):
@@ -28,49 +29,138 @@ class DbsTemplate(AbstractDatabaseElement[T_OBJECTMODEL]):
         self, database: IDatabase, standard_objects: Optional[list[str]] = None
     ):
         """Initialize any necessary attributes."""
+        self._objects: dict[str, T_OBJECTMODEL] = {}
+        self._mutated: set[str] = set()
+        self._deleted: set[str] = set()
+        self._last_modified: dict[str, datetime] = {}
+
         self._database = database
         self.input_path = database.input_path / self.dir_name
         self.output_path = database.output_path / self.dir_name
         self.standard_objects = standard_objects
 
-    def get(self, name: str) -> T_OBJECTMODEL:
-        """Return an object of the type of the database with the given name.
+    ## Public
+    ## IO
+    def load(self, names: list[str] | None = None):
+        """Read all objects from self.input_path and add them to the in-memory database."""
+        if not self.input_path.exists():
+            return
+
+        for obj_dir in self.input_path.iterdir():
+            path = obj_dir / f"{obj_dir.name}.toml"
+
+            if names is not None and path.stem not in names:
+                continue
+
+            try:
+                obj = self._read_object(path)
+            except Exception as e:
+                logger.warning(f"Failed to load {path} due to {e}, skipping...")
+                continue
+
+            self._last_modified[path.stem] = datetime.fromtimestamp(
+                path.stat().st_mtime
+            )
+            self.add(obj, overwrite=True)
+
+        # Loading should not mark mutations
+        self._mutated.clear()
+        self._deleted.clear()
+
+    def flush(self):
+        """Write all staged changes to disk."""
+        self.input_path.mkdir(parents=True, exist_ok=True)
+
+        for name in self._mutated:
+            obj = self._objects[name]
+            path = self._object_path(self.input_path, name)
+
+            try:
+                if path.parent.exists():
+                    shutil.rmtree(path.parent)
+            except OSError as e:
+                raise DatabaseError(
+                    f"Failed to delete input for `{name}` due to: {e}"
+                ) from e
+
+            try:
+                if (self.output_path / name).exists():
+                    shutil.rmtree(self.output_path / name)
+            except OSError as e:
+                raise DatabaseError(
+                    f"Failed to delete output for `{name}` due to: {e}"
+                ) from e
+
+            self._write_object(obj, path)
+            self._last_modified[name] = datetime.now()
+
+        # remove deleted
+        for name in self._deleted:
+            try:
+                if (self.input_path / name).exists():
+                    shutil.rmtree(self.input_path / name)
+            except OSError as e:
+                raise DatabaseError(
+                    f"Failed to delete input for `{name}` due to: {e}"
+                ) from e
+
+            try:
+                if (self.output_path / name).exists():
+                    shutil.rmtree(self.output_path / name)
+            except OSError as e:
+                raise DatabaseError(
+                    f"Failed to delete output for `{name}` due to: {e}"
+                ) from e
+
+            self._last_modified.pop(name, None)
+
+        self._mutated.clear()
+        self._deleted.clear()
+
+    def used_by_higher_level(self, name: str) -> list[str]:
+        """Check if an object is used in a higher level object.
 
         Parameters
         ----------
         name : str
-            name of the object to be returned
+            name of the object to be checked
 
         Returns
         -------
-        Object
-            object of the type of the specified object model
+        list[str]
+            list of higher level objects that use the object
+        """
+        # If this function is not implemented for the object type, it cannot be used in a higher
+        # level object. By default, return an empty list
+        return []
+
+    def list_all(self) -> list[T_OBJECTMODEL]:
+        """Return a list of all objects that currently exist in the database."""
+        return list(self._objects.values())
+
+    ## In memory mutation
+    def add(self, obj: T_OBJECTMODEL, overwrite: bool = False):
+        """Add an object to the in-memory database, and mark it for addition during the next flush.
+
+        Parameters
+        ----------
+        obj : Object
+            object to be added to the database
+        overwrite : bool, optional
+            whether to overwrite an existing object with the same name, by default False
 
         Raises
         ------
-        DoesNotExistError
-            Raise error if the object does not exist.
+        AlreadyExistsError
+            Raise error if name is already in use and overwrite is False.
+        IsStandardObjectError
+            Raise error if object to be added is a standard object and overwrite is True.
+        IsUsedInError
+            Raise error if object to be added is already in use and overwrite is True.
         """
-        # Make the full path to the object
-        full_path = self.input_path / name / f"{name}.toml"
-
-        # Check if the object exists
-        if not Path(full_path).is_file():
-            raise DoesNotExistError(name, self.display_name)
-
-        # Load and return the object
-        return self._object_class.load_file(full_path)
-
-    def summarize_objects(self) -> dict[str, list[Any]]:
-        """Return a dictionary with info on the objects that currently exist in the database.
-
-        Returns
-        -------
-        dict[str, list[Any]]
-            A dictionary that contains the keys: `name`, `description`, `path`  and `last_modification_date`.
-            Each key has a list of the corresponding values, where the index of the values corresponds to the same object.
-        """
-        return self._get_object_summary()
+        self._assert_can_be_added(obj, overwrite=overwrite)
+        self._objects[obj.name] = obj
+        self._mutated.add(obj.name)
 
     def copy(self, old_name: str, new_name: str, new_description: str):
         """Copy (duplicate) an existing object, and give it a new name.
@@ -93,83 +183,20 @@ class DbsTemplate(AbstractDatabaseElement[T_OBJECTMODEL]):
         DatabaseError
             Raise error if the saving of the object fails.
         """
-        copy_object = self.get(old_name)
-        copy_object.name = new_name
-        copy_object.description = new_description
+        source = self.get(old_name).model_copy(deep=True)
+        source.name = new_name
+        source.description = new_description
+        source.model_validate(source)
 
-        # After changing the name and description, re-trigger the validators
-        copy_object.model_validate(copy_object)
+        self.add(source)
 
-        # Checking whether the new name is already in use
-        self._validate_to_save(copy_object, overwrite=False)
-
-        # Write only the toml file
-        toml_path = self.input_path / new_name / f"{new_name}.toml"
-        toml_path.parent.mkdir(parents=True)
-        write_toml(copy_object.model_dump(exclude_none=True), toml_path)
-
-        # Then copy all the accompanied files
-        src = self.input_path / old_name
-        dest = self.input_path / new_name
-
-        EXCLUDE = [".spw", ".toml"]
-        for file in src.glob("*"):
-            if file.suffix in EXCLUDE:
-                continue
-            if file.is_dir():
-                shutil.copytree(file, dest / file.name, dirs_exist_ok=True)
-            else:
-                shutil.copy2(file, dest / file.name)
-
-    def save(
-        self,
-        object_model: T_OBJECTMODEL,
-        overwrite: bool = False,
-    ):
-        """Save an object in the database and all associated files.
-
-        This saves the toml file and any additional files attached to the object.
-
-        Parameters
-        ----------
-        object_model : Object
-            object to be saved in the database
-        overwrite : bool, optional
-            whether to overwrite the object if it already exists in the
-            database, by default False
-
-        Raises
-        ------
-        AlreadyExistsError
-            Raise error if object to be saved already exists.
-        IsStandardObjectError
-            Raise error if object to be overwritten is a standard object.
-        IsUsedInError
-            Raise error if object to be overwritten is already in use.
-        DatabaseError
-            Raise error if the overwriting of the object fails.
-        """
-        self._validate_to_save(object_model, overwrite=overwrite)
-
-        # If the folder doesnt exist yet, make the folder and save the object
-        if not (self.input_path / object_model.name).exists():
-            (self.input_path / object_model.name).mkdir()
-
-        # Save the object and any additional files
-        object_model.save(
-            self.input_path / object_model.name / f"{object_model.name}.toml",
-        )
-
-    def delete(self, name: str, toml_only: bool = False):
-        """Delete an already existing object as well as its outputs from the database.
+    def delete(self, name: str):
+        """Delete an already existing object from the in-memory database and mark it for deletion during the next flush.
 
         Parameters
         ----------
         name : str
             name of the object to be deleted
-        toml_only : bool, optional
-            whether to only delete the toml file or the entire folder. If the folder is empty after deleting the toml,
-            it will always be deleted. By default False
 
         Raises
         ------
@@ -182,43 +209,72 @@ class DbsTemplate(AbstractDatabaseElement[T_OBJECTMODEL]):
         DatabaseError
             Raise error if the deletion of the object fails.
         """
-        # Check if the object is a standard object. If it is, raise an error
-        if self._check_standard_objects(name):
-            raise IsStandardObjectError(name, self.display_name)
-
-        # Check if object is used in a higher level object. If it is, raise an error
-        if used_in := self.check_higher_level_usage(name):
-            raise IsUsedInError(
-                name, self.display_name, self._higher_lvl_object, used_in
-            )
-
-        # Check if the object exists
-        toml_path = self.input_path / name / f"{name}.toml"
-        if not toml_path.exists():
-            raise DoesNotExistError(name, self.display_name)
+        self._assert_can_be_deleted(name)
 
         # Once all checks are passed, delete the object
-        toml_path.unlink(missing_ok=True)
+        del self._objects[name]
+        self._deleted.add(name)
+        self._mutated.discard(name)
 
-        # Delete the entire folder
-        if not list(toml_path.parent.iterdir()):
-            shutil.rmtree(toml_path.parent)
-        elif not toml_only:
-            try:
-                shutil.rmtree(toml_path.parent)
-            except OSError as e:
-                raise DatabaseError(f"Failed to delete `{name}` due to: {e}") from e
+    def get(self, name: str) -> T_OBJECTMODEL:
+        """Return an object of the type of the database with the given name.
 
-        # Delete output
-        if (self.output_path / name).exists():
-            try:
-                shutil.rmtree(self.output_path / name)
-            except OSError as e:
-                raise DatabaseError(
-                    f"Failed to delete output of `{name}` due to: {e}"
-                ) from e
+        Parameters
+        ----------
+        name : str
+            name of the object to be returned
 
-    def _check_standard_objects(self, name: str) -> bool:
+        Returns
+        -------
+        Object
+            object of the type of the specified object model
+
+        Raises
+        ------
+        DoesNotExistError
+            Raise error if the object does not exist.
+        """
+        self._assert_has_object(name)
+        return self._objects[name].model_copy(deep=True)
+
+    ## Query / Info methods
+    def summarize_objects(self) -> dict[str, list[Any]]:
+        """Return a dictionary with info on the objects that currently exist in the database.
+
+        Returns
+        -------
+        dict[str, list[Any]]
+            A dictionary that contains the keys: `name`, `description`, `path`  and `last_modification_date`.
+            Each key has a list of the corresponding values, where the index of the values corresponds to the same object.
+        """
+        names = list(self._objects)
+        paths = [self._object_path(self.input_path, name) for name in names]
+        descriptions = [obj.description for obj in self._objects.values()]
+        last_modification_date = [self._last_modified.get(name) for name in names]
+        objects = {
+            "name": names,
+            "description": descriptions,
+            "path": paths,
+            "last_modification_date": last_modification_date,
+        }
+        return objects
+
+    ## Private methods
+    def _read_object(self, path: Path) -> T_OBJECTMODEL:
+        """Read object from disk, overwritable function that is called in `flush`."""
+        return self._object_class.load_file(path)
+
+    def _write_object(self, obj: T_OBJECTMODEL, path: Path) -> None:
+        """Write object to disk, overwritable function that is called in `flush`."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        obj.save(path)
+
+    # Helpers
+    def _object_path(self, base: Path, name: str):
+        """Get the path to the toml file of an object with a given name."""
+        return base / name / f"{name}.toml"
+
+    def _is_standard_object(self, name: str) -> bool:
         """Check if an object is a standard object.
 
         Parameters
@@ -235,82 +291,39 @@ class DbsTemplate(AbstractDatabaseElement[T_OBJECTMODEL]):
             return name in self.standard_objects
         return False
 
-    def check_higher_level_usage(self, name: str) -> list[str]:
-        """Check if an object is used in a higher level object.
+    def _has_object(self, name: str) -> bool:
+        """Check if an object with the given name exists in the database."""
+        return name in self._objects
 
-        Parameters
-        ----------
-        name : str
-            name of the object to be checked
+    # Validation
+    def _assert_can_be_added(
+        self, object_model: T_OBJECTMODEL, overwrite: bool
+    ) -> None:
+        """Validate if the object can be added to the database and raise appropriate errors if not."""
+        if self._has_object(object_model.name):
+            if overwrite:
+                self._assert_can_be_deleted(object_model.name)
+            else:
+                raise AlreadyExistsError(object_model.name, self.display_name)
 
-        Returns
-        -------
-        list[str]
-            list of higher level objects that use the object
-        """
-        # If this function is not implemented for the object type, it cannot be used in a higher
-        # level object. By default, return an empty list
-        return []
+    def _assert_can_be_deleted(self, name: str) -> None:
+        """Validate if the object can be deleted from the database and raise appropriate errors if not."""
+        if self._is_standard_object(name):
+            raise IsStandardObjectError(name, self.display_name)
 
-    def _get_object_summary(self) -> dict[str, list[Any]]:
-        """Get a dictionary with all the toml paths and last modification dates that exist in the database of the given object_type.
+        if used_in := self.used_by_higher_level(name):
+            raise IsUsedInError(
+                name, self.display_name, self._higher_lvl_object, used_in
+            )
 
-        Returns
-        -------
-        dict[str, Any]
-            A dictionary that contains the keys: `name`, `description`, `path`  and `last_modification_date`.
-            Each key has a list of the corresponding values, where the index of the values corresponds to the same object.
-        """
-        # If the toml doesnt exist, we might be in the middle of saving a new object or could be a broken object.
-        # In any case, we should not list it in the database
-        directories = [
-            dir
-            for dir in self.input_path.iterdir()
-            if (dir / f"{dir.name}.toml").is_file()
-        ]
-        paths = [Path(dir / f"{dir.name}.toml") for dir in directories]
+        if name not in self._objects:
+            raise DoesNotExistError(name, self.display_name)
 
-        names = [self._read_variable_in_toml("name", path) for path in paths]
-        descriptions = [
-            self._read_variable_in_toml("description", path) for path in paths
-        ]
+    def _assert_has_object(self, name: str) -> None:
+        """Validate if the object exists in the database and raise an error if not."""
+        if not self._has_object(name):
+            raise DoesNotExistError(name, self.display_name)
 
-        last_modification_date = [
-            datetime.fromtimestamp(file.stat().st_mtime) for file in paths
-        ]
-
-        objects = {
-            "name": names,
-            "description": descriptions,
-            "path": paths,
-            "last_modification_date": last_modification_date,
-        }
-        return objects
-
-    @staticmethod
-    def _read_variable_in_toml(variable_name: str, toml_path: Path) -> str:
-        data = read_toml(toml_path)
-        return data.get(variable_name, "")
-
-    def _validate_to_save(self, object_model: T_OBJECTMODEL, overwrite: bool) -> None:
-        """Validate if the object can be saved.
-
-        Parameters
-        ----------
-        object_model : Object
-            object to be validated
-
-        Raises
-        ------
-        DatabaseError
-            Raise error if name is already in use.
-        """
-        # Check if the object exists
-        object_exists = object_model.name in self.summarize_objects()["name"]
-
-        # If you want to overwrite the object, and the object already exists, first delete it. If it exists and you
-        # don't want to overwrite, raise an error.
-        if overwrite and object_exists:
-            self.delete(object_model.name, toml_only=True)
-        elif not overwrite and object_exists:
-            raise AlreadyExistsError(object_model.name, self.display_name)
+    def __del__(self):
+        if self._mutated or self._deleted:
+            logger.warning("Database object destroyed with unflushed changes.")

--- a/flood_adapt/dbs_classes/interface/element.py
+++ b/flood_adapt/dbs_classes/interface/element.py
@@ -10,112 +10,38 @@ T_OBJECT_MODEL = TypeVar("T_OBJECT_MODEL", bound=Object)
 class AbstractDatabaseElement(ABC, Generic[T_OBJECT_MODEL]):
     input_path: Path
     output_path: Path
+    _objects: dict[str, T_OBJECT_MODEL]
 
     @abstractmethod
-    def __init__(self):
-        """Abstract class for database elements."""
-        pass
+    def __init__(self, database, standard_objects: list[str] | None = None): ...
+
+    ## IO
+    @abstractmethod
+    def load(self): ...
 
     @abstractmethod
-    def get(self, name: str) -> T_OBJECT_MODEL:
-        """Return the object of the type of the database with the given name.
+    def flush(self): ...
 
-        Parameters
-        ----------
-        name : str
-            name of the object to be returned
-
-        Returns
-        -------
-        IObject
-            object of the type of the specified object model
-        """
-        pass
+    ## In memory mutations
+    @abstractmethod
+    def add(self, obj: T_OBJECT_MODEL, overwrite: bool = False) -> None: ...
 
     @abstractmethod
-    def summarize_objects(self) -> dict[str, list[Any]]:
-        """Return a dictionary with info on the objects that currently exist in the database.
-
-        Returns
-        -------
-        dict[str, Any]
-            Includes 'name', 'description', 'path' and 'last_modification_date' info, as well as the objects themselves
-        """
-        pass
+    def get(self, name: str) -> T_OBJECT_MODEL: ...
 
     @abstractmethod
-    def copy(self, old_name: str, new_name: str, new_description: str):
-        """Copy (duplicate) an existing object, and give it a new name.
-
-        Parameters
-        ----------
-        old_name : str
-            name of the existing measure
-        new_name : str
-            name of the new measure
-        new_description : str
-            description of the new measure
-        """
-        pass
+    def copy(self, old_name: str, new_name: str, new_description: str): ...
 
     @abstractmethod
-    def save(
-        self,
-        object_model: T_OBJECT_MODEL,
-        overwrite: bool = False,
-    ):
-        """Save an object in the database.
+    def delete(self, name: str, toml_only: bool = False): ...
 
-        This only saves the toml file. If the object also contains a geojson file, this should be saved separately.
+    # Query
+    @abstractmethod
+    def summarize_objects(self) -> dict[str, list[Any]]: ...
 
-        Parameters
-        ----------
-        object_model : Object
-            object to be saved in the database
-        overwrite : bool, optional
-            whether to overwrite the object if it already exists in the
-            database, by default False
-        toml_only : bool, optional
-            whether to only save the toml file or all associated data. By default, save everything
-
-        Raises
-        ------
-        ValueError
-            Raise error if name is already in use.
-        """
-        pass
+    # Helpers
+    @abstractmethod
+    def used_by_higher_level(self, name: str) -> list[str]: ...
 
     @abstractmethod
-    def delete(self, name: str, toml_only: bool = False):
-        """Delete an already existing object in the database.
-
-        Parameters
-        ----------
-        name : str
-            name of the object to be deleted
-        toml_only : bool, optional
-            whether to only delete the toml file or the entire folder. If the folder is empty after deleting the toml,
-            it will always be deleted. By default False
-
-        Raises
-        ------
-        ValueError
-            Raise error if object to be deleted is already in use.
-        """
-        pass
-
-    @abstractmethod
-    def check_higher_level_usage(self, name: str) -> list[str]:
-        """Check if an object is used in a higher level object.
-
-        Parameters
-        ----------
-        name : str
-            name of the object to be checked
-
-        Returns
-        -------
-        list[str]
-            list of higher level objects that use the object
-        """
-        pass
+    def list_all(self) -> list[T_OBJECT_MODEL]: ...

--- a/flood_adapt/dbs_classes/interface/static.py
+++ b/flood_adapt/dbs_classes/interface/static.py
@@ -16,6 +16,11 @@ class IDbsStatic(ABC):
     def get_aggregation_areas(self) -> dict: ...
 
     @abstractmethod
+    def get_aggregation_area_by_type_and_name(
+        self, area_type: str, area_name: str
+    ) -> gpd.GeoDataFrame: ...
+
+    @abstractmethod
     def get_model_boundary(self) -> gpd.GeoDataFrame: ...
 
     @abstractmethod

--- a/flood_adapt/flood_adapt.py
+++ b/flood_adapt/flood_adapt.py
@@ -144,7 +144,8 @@ class FloodAdapt:
         DatabaseError
             If the measure object is not valid.
         """
-        self.database.measures.save(measure, overwrite=overwrite)
+        self.database.measures.add(measure, overwrite=overwrite)
+        self.database.measures.flush()
 
     def delete_measure(self, name: str) -> None:
         """Delete an measure from the database.
@@ -160,6 +161,7 @@ class FloodAdapt:
             If the measure does not exist.
         """
         self.database.measures.delete(name)
+        self.database.measures.flush()
 
     def copy_measure(self, old_name: str, new_name: str, new_description: str) -> None:
         """Copy a measure in the database.
@@ -174,6 +176,7 @@ class FloodAdapt:
             The description of the new measure
         """
         self.database.measures.copy(old_name, new_name, new_description)
+        self.database.measures.flush()
 
     def get_green_infra_table(self, measure_type: str) -> pd.DataFrame:
         """Return a table with different types of green infrastructure measures and their infiltration depths.
@@ -263,7 +266,8 @@ class FloodAdapt:
             If the strategy object is not valid.
             If the strategy object already exists.
         """
-        self.database.strategies.save(strategy, overwrite=overwrite)
+        self.database.strategies.add(strategy, overwrite=overwrite)
+        self.database.strategies.flush()
 
     def delete_strategy(self, name: str) -> None:
         """
@@ -280,6 +284,7 @@ class FloodAdapt:
             If the strategy does not exist.
         """
         self.database.strategies.delete(name)
+        self.database.strategies.flush()
 
     def copy_strategy(self, old_name: str, new_name: str, new_description: str) -> None:
         """Copy a strategy in the database.
@@ -294,6 +299,7 @@ class FloodAdapt:
             The description of the new strategy
         """
         self.database.strategies.copy(old_name, new_name, new_description)
+        self.database.strategies.flush()
 
     # Events
     def get_events(self) -> dict[str, Any]:
@@ -388,7 +394,8 @@ class FloodAdapt:
         DatabaseError
             If the event object is not valid.
         """
-        self.database.events.save(event, overwrite=overwrite)
+        self.database.events.add(event, overwrite=overwrite)
+        self.database.events.flush()
 
     def delete_event(self, name: str) -> None:
         """Delete an event from the database.
@@ -405,6 +412,7 @@ class FloodAdapt:
             If the event is used in a scenario.
         """
         self.database.events.delete(name)
+        self.database.events.flush()
 
     def copy_event(self, old_name: str, new_name: str, new_description: str) -> None:
         """Copy an event in the database.
@@ -419,6 +427,7 @@ class FloodAdapt:
             The description of the new event
         """
         self.database.events.copy(old_name, new_name, new_description)
+        self.database.events.flush()
 
     def plot_event_forcing(
         self, event: Event, forcing_type: ForcingType
@@ -525,7 +534,8 @@ class FloodAdapt:
         DatabaseError
             If the projection object is not valid.
         """
-        self.database.projections.save(projection, overwrite=overwrite)
+        self.database.projections.add(projection, overwrite=overwrite)
+        self.database.projections.flush()
 
     def delete_projection(self, name: str) -> None:
         """Delete a projection from the database.
@@ -542,6 +552,7 @@ class FloodAdapt:
             If the projection is used in a scenario.
         """
         self.database.projections.delete(name)
+        self.database.projections.flush()
 
     def copy_projection(
         self, old_name: str, new_name: str, new_description: str
@@ -558,6 +569,7 @@ class FloodAdapt:
             The description of the new projection
         """
         self.database.projections.copy(old_name, new_name, new_description)
+        self.database.projections.flush()
 
     def get_slr_scn_names(
         self,
@@ -684,7 +696,8 @@ class FloodAdapt:
             If the scenario object is not valid or if it already exists and overwrite is False.
 
         """
-        self.database.scenarios.save(scenario, overwrite=overwrite)
+        self.database.scenarios.add(scenario, overwrite=overwrite)
+        self.database.scenarios.flush()
 
     def delete_scenario(self, name: str) -> None:
         """Delete a scenario from the database.
@@ -700,6 +713,7 @@ class FloodAdapt:
             If the scenario does not exist.
         """
         self.database.scenarios.delete(name)
+        self.database.scenarios.flush()
 
     def run_scenario(self, scenario_name: Union[str, list[str]]) -> None:
         """Run a scenario hazard and impacts.
@@ -1213,7 +1227,8 @@ class FloodAdapt:
         DatabaseError
             If the benefit object is not valid.
         """
-        self.database.benefits.save(benefit, overwrite=overwrite)
+        self.database.benefits.add(benefit, overwrite=overwrite)
+        self.database.benefits.flush()
 
     def delete_benefit(self, name: str) -> None:
         """Delete a benefit object from the database.
@@ -1229,6 +1244,7 @@ class FloodAdapt:
             If the benefit object does not exist.
         """
         self.database.benefits.delete(name)
+        self.database.benefits.flush()
 
     def check_benefit_scenarios(self, benefit: Benefit) -> pd.DataFrame:
         """Return a dataframe with the scenarios needed for this benefit assessment run.

--- a/flood_adapt/misc/utils.py
+++ b/flood_adapt/misc/utils.py
@@ -209,7 +209,7 @@ def path_exists_and_absolute(
 ) -> Path:
     """Take a path which can be absolute or relative, and return an absolute path.
 
-    When the obj_path is relative, it is made absolute relative to the argument_path.
+    When the obj_path is relative, it is made absolute relative to the argument_path's parent.
     """
     obj_path = Path(obj_path)
     if obj_path.is_absolute():

--- a/flood_adapt/objects/events/event_factory.py
+++ b/flood_adapt/objects/events/event_factory.py
@@ -75,7 +75,7 @@ class EventFactory:
         return Mode(data.get("mode"))
 
     @staticmethod
-    def load_file(toml_file: Path, load_all: bool = False) -> Event | EventSet:
+    def load_file(toml_file: Path) -> Event | EventSet:
         """Return event object based on toml file.
 
         Parameters
@@ -90,7 +90,7 @@ class EventFactory:
         """
         mode = EventFactory.read_mode(toml_file)
         if mode == Mode.risk:
-            return EventSet.load_file(toml_file, load_all=load_all)
+            return EventSet.load_file(toml_file)
         elif mode == Mode.single_event:
             template = Template(EventFactory.read_template(toml_file))
             event_type = EventFactory.get_event_from_template(template)

--- a/flood_adapt/objects/events/event_set.py
+++ b/flood_adapt/objects/events/event_set.py
@@ -67,18 +67,6 @@ class EventSet(Object):
         else:
             raise ValueError("Either `sub_events` or `file_path` must be provided.")
 
-    def _post_load(
-        self,
-        file_path: Path | str | os.PathLike,
-        *,
-        load_all: bool = False,
-        sub_events: List[Event] | None = None,
-        **kwargs,
-    ) -> None:
-        """Post-load hook, called at the end of `load_file`, to perform any additional loading steps after loading from file."""
-        if load_all:
-            self.load_sub_events(sub_events=sub_events, file_path=file_path)
-
     def save_additional(self, output_dir: Path | str | os.PathLike) -> None:
         if self._events is None:
             return

--- a/flood_adapt/objects/measures/measures.py
+++ b/flood_adapt/objects/measures/measures.py
@@ -5,13 +5,17 @@ from typing import Any, Optional, TypeVar
 
 import geopandas as gpd
 import pyproj
-from pydantic import Field, field_serializer, field_validator, model_validator
+from pydantic import (
+    Field,
+    PrivateAttr,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 
 from flood_adapt.config.site import Site
 from flood_adapt.misc.utils import (
     path_exists_and_absolute,
-    resolve_filepath,
-    save_file_to_database,
 )
 from flood_adapt.objects.forcing import unit_system as us
 from flood_adapt.objects.object_model import Object
@@ -145,6 +149,7 @@ class Measure(Object):
         min_length=1,
         description="Path to a polygon file, either absolute or relative to the measure path.",
     )
+    _gdf: Optional[gpd.GeoDataFrame] = PrivateAttr(default=None)
 
     aggregation_area_type: Optional[str] = None
     aggregation_area_name: Optional[str] = None
@@ -191,11 +196,22 @@ class Measure(Object):
 
     def save_additional(self, output_dir: Path | str | os.PathLike) -> None:
         if self.polygon_file:
-            Path(output_dir).mkdir(parents=True, exist_ok=True)
-            src_path = resolve_filepath("measures", self.name, self.polygon_file)
-            path = save_file_to_database(src_path, Path(output_dir))
-            # Update the shapefile path in the object so it is saved in the toml file as well
-            self.polygon_file = path.name
+            gdf = self.read_gdf()
+            if gdf is None:
+                raise ValueError(
+                    f"Cannot save measure {self.name}: `polygon_file` is set but no GeoDataFrame could be read from it."
+                )
+            filename = Path(self.polygon_file).name
+            file_path = Path(output_dir, filename)
+            gdf.to_file(file_path)
+
+    def read_gdf(self, reload: bool = False) -> gpd.GeoDataFrame | None:
+        """Read the polygon file as a GeoDataFrame if it exists."""
+        if self._gdf is not None and not reload:
+            return self._gdf
+        if self.polygon_file:
+            self._gdf = gpd.read_file(self.polygon_file)
+        return self._gdf
 
 
 class HazardMeasure(Measure):

--- a/flood_adapt/workflows/benefit_runner.py
+++ b/flood_adapt/workflows/benefit_runner.py
@@ -169,6 +169,7 @@ class BenefitRunner:
         benefit : Benefit
         """
         # Iterate through the scenarios needed and create them if not existing
+        flush_required = False
         for _, row in self.scenarios.iterrows():
             if row["scenario created"] == "No":
                 name = "_".join([row["projection"], row["event"], row["strategy"]])
@@ -183,7 +184,10 @@ class BenefitRunner:
                         projection=row["projection"],
                         strategy=row["strategy"],
                     )
-                    self.database.scenarios.save(scenario)
+                    self.database.scenarios.add(scenario)
+                    flush_required = True
+        if flush_required:
+            self.database.scenarios.flush()
 
     def ready_to_run(self) -> bool:
         """Check if all the required scenarios have already been run.

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,32 +5,151 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_h43fde53_912.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.5-h2b0a6b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-16.2.0-h96af755_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.9.0-hb700be7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-25.3.4-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.0-hb700be7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250512.1-cxx17_hba17884_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.4.1-hb56ce9e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.4.1-hd85de46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2025.4.1-hd85de46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2025.4.1-hd41364c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.4.1-hb56ce9e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.4.1-hb56ce9e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.4.1-hb56ce9e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2025.4.1-hd41364c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2025.4.1-h1862bb8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2025.4.1-h1862bb8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.4.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.4.1-h0767aad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.4.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.60.0-h61e6d4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.1-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.13-hb700be7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-h5347b49_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.15.0-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.12-hd63d673_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.4.0-h3b84278_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shaderc-2025.5-h718be3e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2026.1-hb700be7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.46-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/0b/f7/85273299ab57117850cc0a936c64151171fac4da49bc6fba0dad984a7c5f/affine-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl
@@ -43,6 +162,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b5/d4/e7bbea08f4c0f0bab819d38c1a613da5f194fba7b19aae3e2b3a27e78886/bottleneck-1.6.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/51/bb/bf7aab772a159614954d84aa832c129624ba6c32faa559dfb200a534e50b/bs4-0.0.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b9/30/7465b650110514fc5c9c3b59935264c35ab56f876322de34efa55367ee4e/cartopy-0.25.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/99/73/3868a695f082f379dce20f19b55451fef4c3f4337824f0991dc1a228301b/census-0.8.24-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -69,6 +189,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/46/4745aa10a1e460f4c8b473eddaffe2c783ac5280e1e5929dd84bd1a1acde/duckdb-1.2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f0/cc/3b7408b8ecf7c1d20ad480c3eaed7619857bf1054b690226e906fdf14258/ffmpeg-1.4.tar.gz
       - pypi: https://files.pythonhosted.org/packages/d4/bb/38cb64a9f1e18f8f6caa6dc08951839f72d58dc5b8daed6b9a090fcd1764/fiat_toolbox-0.1.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/78/be204fb409b59876ef4658710a022794f16f779a3e9e7df654acc38b2104/fiona-1.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
@@ -154,6 +275,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/be/212882c450bba74fc8d7d35cbd57e4af84792f0a56194819d98106b075af/pyproj-3.7.2-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/06/cad54e8ce758bd836ee5411691cbd49efeb9cc611b374670fce299519334/pyshp-3.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c0/01/eb465e19137b36ba683417e982907aa9c7df1fb0b968e1424e5d678ba0dc/pystac-1.14.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl
@@ -203,21 +325,77 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl
       - pypi: ./
       win-64:
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.4-h477c42c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-8.0.1-gpl_hb2d76f6_912.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.15.0-h765892d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.14.1-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fribidi-1.0.16-hfd05255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdk-pixbuf-2.44.5-h1f5b9c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glslang-16.2.0-h294ba9c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.14-hac47afa_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-12.3.2-h5a1b470_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.2-h637d24d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lame-3.100-hcfcfb64_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h6470a55_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.2.0-hfd05255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.2.0-hfd05255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.2.0-hfd05255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h51727cc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.3-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype-2.14.1-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype6-2.14.1-hdbac1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.86.3-h0c9aed9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.3.0-ha71e874_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.1.2-hfd05255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjxl-0.11.2-hf3f85d1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.2-hfd05255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopus-1.6.1-h6a83c73_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.55-h7351971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/librsvg-2.60.0-hd5e4115_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.1-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.1-h8f73337_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libusb-1.0.29-h1839187_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h5112557_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libvulkan-loader-1.4.341.0-h477610d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.6.0-h4d5522a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.1-h3cfd58e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.1-h779ef1b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.6.0-hb17fa0b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pango-1.56.4-h03d888a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.47-hd2b5f0e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.46.4-h5112557_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.12-h0159041_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.32.56-h5112557_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sdl3-3.4.0-h5112557_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/shaderc-2025.5-h8fa7867_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/spirv-tools-2026.1-h49e36cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-4.0.1-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h2b53caa_33.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_33.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_33.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_33.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: https://files.pythonhosted.org/packages/0b/f7/85273299ab57117850cc0a936c64151171fac4da49bc6fba0dad984a7c5f/affine-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
@@ -229,6 +407,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/48/ad/d71da675eef85ac153eef5111ca0caa924548c9591da00939bcabba8de8e/bottleneck-1.6.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/51/bb/bf7aab772a159614954d84aa832c129624ba6c32faa559dfb200a534e50b/bs4-0.0.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1d/52/3a57ecb4598c33ee06b512d3686e46b3983e65abd6ec94c5262d01930ed9/cartopy-0.25.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/99/73/3868a695f082f379dce20f19b55451fef4c3f4337824f0991dc1a228301b/census-0.8.24-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl
@@ -256,6 +435,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0c/d5/c5db1ea3394c6e1732fb3286b3bd878b59507a8f77d32a2cebda7d7b7cd4/donfig-0.8.1.post1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/eb/c9/896e8ced7b408df81e015fe0c6497cda46c92d9dfc8bf84b6d13f5dad473/duckdb-1.2.2-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f0/cc/3b7408b8ecf7c1d20ad480c3eaed7619857bf1054b690226e906fdf14258/ffmpeg-1.4.tar.gz
       - pypi: https://files.pythonhosted.org/packages/d4/bb/38cb64a9f1e18f8f6caa6dc08951839f72d58dc5b8daed6b9a090fcd1764/fiat_toolbox-0.1.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/0d/914fd3c4c32043c2c512fa5021e83b2348e1b7a79365d75a0a37cb545362/fiona-1.10.1-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/27/cd/c883e1a7c447479d6e13985565080e3fea88ab5a107c21684c813dba1875/flexcache-0.3-py3-none-any.whl
@@ -340,6 +520,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/a6/6fe724b72b70f2b00152d77282e14964d60ab092ec225e67c196c9b463e5/pyproj-3.7.2-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/06/cad54e8ce758bd836ee5411691cbd49efeb9cc611b374670fce299519334/pyshp-3.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c0/01/eb465e19137b36ba683417e982907aa9c7df1fb0b968e1424e5d678ba0dc/pystac-1.14.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl
@@ -393,32 +574,151 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_h43fde53_912.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.5-h2b0a6b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-16.2.0-h96af755_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.9.0-hb700be7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-25.3.4-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45-default_hbd61a6d_104.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.0-hb700be7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250512.1-cxx17_hba17884_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h9ec8514_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.4.1-hb56ce9e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.4.1-hd85de46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2025.4.1-hd85de46_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2025.4.1-hd41364c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.4.1-hb56ce9e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.4.1-hb56ce9e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.4.1-hb56ce9e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2025.4.1-hd41364c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2025.4.1-h1862bb8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2025.4.1-h1862bb8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.4.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.4.1-h0767aad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.4.1-hecca717_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.60.0-h61e6d4b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.1-h0c1763c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.13-hb700be7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-h5347b49_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.15.0-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.12-hd63d673_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.4.0-h3b84278_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/shaderc-2025.5-h718be3e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2026.1-hb700be7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_ha0e22de_103.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.46-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/0b/f7/85273299ab57117850cc0a936c64151171fac4da49bc6fba0dad984a7c5f/affine-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
@@ -441,6 +741,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b5/d4/e7bbea08f4c0f0bab819d38c1a613da5f194fba7b19aae3e2b3a27e78886/bottleneck-1.6.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/7e/50/fc9680058e63161f2f63165b84c957a0df1415431104c408e8104a3a18ef/branca-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/51/bb/bf7aab772a159614954d84aa832c129624ba6c32faa559dfb200a534e50b/bs4-0.0.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b9/30/7465b650110514fc5c9c3b59935264c35ab56f876322de34efa55367ee4e/cartopy-0.25.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/99/73/3868a695f082f379dce20f19b55451fef4c3f4337824f0991dc1a228301b/census-0.8.24-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -477,6 +778,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f0/cc/3b7408b8ecf7c1d20ad480c3eaed7619857bf1054b690226e906fdf14258/ffmpeg-1.4.tar.gz
       - pypi: https://files.pythonhosted.org/packages/d4/bb/38cb64a9f1e18f8f6caa6dc08951839f72d58dc5b8daed6b9a090fcd1764/fiat_toolbox-0.1.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/91/7216b27286936c16f5b4d0c530087e4a54eead683e6b0b73dd0c64844af6/filelock-3.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/78/be204fb409b59876ef4658710a022794f16f779a3e9e7df654acc38b2104/fiona-1.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
@@ -613,6 +915,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/36/f7/cf8bec9024625947e1a71441906f60a5fa6f9e4c441c4428037e73b1fcc8/pyogrio-0.12.1-cp312-cp312-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/be/212882c450bba74fc8d7d35cbd57e4af84792f0a56194819d98106b075af/pyproj-3.7.2-cp312-cp312-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/82/06/cad54e8ce758bd836ee5411691cbd49efeb9cc611b374670fce299519334/pyshp-3.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c0/01/eb465e19137b36ba683417e982907aa9c7df1fb0b968e1424e5d678ba0dc/pystac-1.14.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/b4/bb7263e12aade3842b938bc5c6958cae79c5ee18992f9b9349019579da0f/pytest_cov-6.3.0-py3-none-any.whl
@@ -700,21 +1003,77 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl
       - pypi: ./
       win-64:
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.11.12-h4c7d964_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.4-h477c42c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-8.0.1-gpl_hb2d76f6_912.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.15.0-h765892d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.14.1-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fribidi-1.0.16-hfd05255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdk-pixbuf-2.44.5-h1f5b9c4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glslang-16.2.0-h294ba9c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.14-hac47afa_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-12.3.2-h5a1b470_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.2-h637d24d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lame-3.100-hcfcfb64_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h6470a55_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.2.0-hfd05255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.2.0-hfd05255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.2.0-hfd05255_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h51727cc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.7.3-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h52bdfb6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype-2.14.1-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype6-2.14.1-hdbac1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.86.3-h0c9aed9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.3.0-ha71e874_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.1.2-hfd05255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjxl-0.11.2-hf3f85d1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.2-hfd05255_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopus-1.6.1-h6a83c73_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.55-h7351971_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/librsvg-2.60.0-hd5e4115_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.51.1-hf5d6505_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.1-h8f73337_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libusb-1.0.29-h1839187_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h5112557_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libvulkan-loader-1.4.341.0-h477610d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.6.0-h4d5522a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.1-h3cfd58e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.1-h779ef1b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.6.0-hb17fa0b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.0-h725018a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pango-1.56.4-h03d888a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.47-hd2b5f0e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.46.4-h5112557_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.12-h0159041_1_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.32.56-h5112557_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/sdl3-3.4.0-h5112557_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/shaderc-2025.5-h8fa7867_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/spirv-tools-2026.1-h49e36cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-4.0.1-hac47afa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-h2c6b04d_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h2b53caa_33.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_33.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_33.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_33.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - pypi: https://files.pythonhosted.org/packages/0b/f7/85273299ab57117850cc0a936c64151171fac4da49bc6fba0dad984a7c5f/affine-2.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl
@@ -736,6 +1095,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/48/ad/d71da675eef85ac153eef5111ca0caa924548c9591da00939bcabba8de8e/bottleneck-1.6.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/7e/50/fc9680058e63161f2f63165b84c957a0df1415431104c408e8104a3a18ef/branca-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/51/bb/bf7aab772a159614954d84aa832c129624ba6c32faa559dfb200a534e50b/bs4-0.0.2-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1d/52/3a57ecb4598c33ee06b512d3686e46b3983e65abd6ec94c5262d01930ed9/cartopy-0.25.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/99/73/3868a695f082f379dce20f19b55451fef4c3f4337824f0991dc1a228301b/census-0.8.24-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl
@@ -772,6 +1132,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/f0/cc/3b7408b8ecf7c1d20ad480c3eaed7619857bf1054b690226e906fdf14258/ffmpeg-1.4.tar.gz
       - pypi: https://files.pythonhosted.org/packages/d4/bb/38cb64a9f1e18f8f6caa6dc08951839f72d58dc5b8daed6b9a090fcd1764/fiat_toolbox-0.1.22-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/76/91/7216b27286936c16f5b4d0c530087e4a54eead683e6b0b73dd0c64844af6/filelock-3.20.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/0d/914fd3c4c32043c2c512fa5021e83b2348e1b7a79365d75a0a37cb545362/fiona-1.10.1-cp312-cp312-win_amd64.whl
@@ -906,6 +1267,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ab/10/7c9f5e428273574e69f217eba3a6c0c42936188ad4dcd9e2c41ebb711188/pyogrio-0.12.1-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/10/5e/1aa9a93198c6b64513c9d7752de7422c06402de6600a8767da1524f9570b/pyparsing-3.2.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/a6/6fe724b72b70f2b00152d77282e14964d60ab092ec225e67c196c9b463e5/pyproj-3.7.2-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/82/06/cad54e8ce758bd836ee5411691cbd49efeb9cc611b374670fce299519334/pyshp-3.0.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c0/01/eb465e19137b36ba683417e982907aa9c7df1fb0b968e1424e5d678ba0dc/pystac-1.14.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/b4/bb7263e12aade3842b938bc5c6958cae79c5ee18992f9b9349019579da0f/pytest_cov-6.3.0-py3-none-any.whl
@@ -1031,6 +1393,17 @@ packages:
   version: 1.0.0
   sha256: fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.15.3-hb03c661_0.conda
+  sha256: d88aa7ae766cf584e180996e92fef2aa7d8e0a0a5ab1d4d49c32390c1b5fff31
+  md5: dcdc58c15961dbf17a0621312b01f5cb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  license_family: GPL
+  purls: []
+  size: 584660
+  timestamp: 1768327524772
 - pypi: https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl
   name: altgraph
   version: 0.17.5
@@ -1053,6 +1426,29 @@ packages:
   - trio>=0.32.0 ; python_full_version >= '3.10' and extra == 'trio'
   - trio>=0.31.0 ; python_full_version < '3.10' and extra == 'trio'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.9.1-hac33072_0.conda
+  sha256: b08ef033817b5f9f76ce62dfcac7694e7b6b4006420372de22494503decac855
+  md5: 346722a0be40f6edc53f12640d301338
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 2706396
+  timestamp: 1718551242397
+- conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
+  sha256: 0524d0c0b61dacd0c22ac7a8067f977b1d52380210933b04141f5099c5b6fec7
+  md5: 3d7c14285d3eb3239a76ff79063f27a5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 1958151
+  timestamp: 1718551737234
 - pypi: https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl
   name: argon2-cffi
   version: 25.1.0
@@ -1115,6 +1511,17 @@ packages:
   requires_dist:
   - typing-extensions>=4.0.0 ; python_full_version < '3.11'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.2-h39aace5_0.conda
+  sha256: a9c114cbfeda42a226e2db1809a538929d2f118ef855372293bd188f71711c48
+  md5: 791365c5f65975051e4e017b5da3abf5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 68072
+  timestamp: 1756738968573
 - pypi: https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl
   name: attrs
   version: 25.4.0
@@ -1446,6 +1853,108 @@ packages:
   purls: []
   size: 152432
   timestamp: 1762967197890
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-he90730b_1.conda
+  sha256: 06525fa0c4e4f56e771a3b986d0fdf0f0fc5a3270830ee47e127a5105bde1b9a
+  md5: bb6c4808bfa69d6f7f6b07e5846ced37
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - icu >=78.1,<79.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libglib >=2.86.3,<3.0a0
+  - libpng >=1.6.53,<1.7.0a0
+  - libstdcxx >=14
+  - libxcb >=1.17.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.46.4,<1.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  - xorg-libsm >=1.2.6,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: LGPL-2.1-only or MPL-1.1
+  purls: []
+  size: 989514
+  timestamp: 1766415934926
+- conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.4-h477c42c_1.conda
+  sha256: 9ee4ad706c5d3e1c6c469785d60e3c2b263eec569be0eac7be33fbaef978bccc
+  md5: 52ea1beba35b69852d210242dd20f97d
+  depends:
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - icu >=78.1,<79.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libglib >=2.86.3,<3.0a0
+  - libpng >=1.6.53,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pixman >=0.46.4,<1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-2.1-only or MPL-1.1
+  purls: []
+  size: 1537783
+  timestamp: 1766416059188
+- pypi: https://files.pythonhosted.org/packages/1d/52/3a57ecb4598c33ee06b512d3686e46b3983e65abd6ec94c5262d01930ed9/cartopy-0.25.0-cp312-cp312-win_amd64.whl
+  name: cartopy
+  version: 0.25.0
+  sha256: efedb82f38409b72becdfee02231126952816d33a68b1c584bd2136713036bfb
+  requires_dist:
+  - numpy>=1.23
+  - matplotlib>=3.6
+  - shapely>=2.0
+  - packaging>=21
+  - pyshp>=2.3
+  - pyproj>=3.3.1
+  - pydata-sphinx-theme ; extra == 'doc'
+  - sphinx ; extra == 'doc'
+  - sphinx-gallery ; extra == 'doc'
+  - pykdtree ; extra == 'speedups'
+  - fiona ; extra == 'speedups'
+  - owslib>=0.27.0 ; extra == 'ows'
+  - pillow>=9.1 ; extra == 'ows'
+  - pillow>=9.1 ; extra == 'plotting'
+  - scipy>=1.9 ; extra == 'plotting'
+  - beautifulsoup4 ; extra == 'srtm'
+  - pytest>=5.1.2 ; extra == 'test'
+  - pytest-mpl>=0.11 ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - coveralls ; extra == 'test'
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/b9/30/7465b650110514fc5c9c3b59935264c35ab56f876322de34efa55367ee4e/cartopy-0.25.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
+  name: cartopy
+  version: 0.25.0
+  sha256: 53c256351433155ef51dde976557212f4e230b8cca4e5d0d9b9a2737ad92959d
+  requires_dist:
+  - numpy>=1.23
+  - matplotlib>=3.6
+  - shapely>=2.0
+  - packaging>=21
+  - pyshp>=2.3
+  - pyproj>=3.3.1
+  - pydata-sphinx-theme ; extra == 'doc'
+  - sphinx ; extra == 'doc'
+  - sphinx-gallery ; extra == 'doc'
+  - pykdtree ; extra == 'speedups'
+  - fiona ; extra == 'speedups'
+  - owslib>=0.27.0 ; extra == 'ows'
+  - pillow>=9.1 ; extra == 'ows'
+  - pillow>=9.1 ; extra == 'plotting'
+  - scipy>=1.9 ; extra == 'plotting'
+  - beautifulsoup4 ; extra == 'srtm'
+  - pytest>=5.1.2 ; extra == 'test'
+  - pytest-mpl>=0.11 ; extra == 'test'
+  - pytest-xdist ; extra == 'test'
+  - pytest-cov ; extra == 'test'
+  - coveralls ; extra == 'test'
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/99/73/3868a695f082f379dce20f19b55451fef4c3f4337824f0991dc1a228301b/census-0.8.24-py3-none-any.whl
   name: census
   version: 0.8.24
@@ -1880,6 +2389,42 @@ packages:
   - xarray
   - pytest ; extra == 'tests'
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+  sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
+  md5: 418c6ca5929a611cbd69204907a83995
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 760229
+  timestamp: 1685695754230
+- conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
+  sha256: 2aa2083c9c186da7d6f975ccfbef654ed54fff27f4bc321dbcd12cee932ec2c4
+  md5: ed2c27bda330e3f0ab41577cf8b9b585
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 618643
+  timestamp: 1685696352968
+- conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
+  sha256: 8bb557af1b2b7983cf56292336a1a1853f26555d9c6cecf1e5b2b96838c9da87
+  md5: ce96f2f470d39bd96ce03945af92e280
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  - libglib >=2.86.2,<3.0a0
+  - libexpat >=2.7.3,<3.0a0
+  license: AFL-2.1 OR GPL-2.0-or-later
+  purls: []
+  size: 447649
+  timestamp: 1764536047944
 - pypi: https://files.pythonhosted.org/packages/dc/0d/bf7ac329c132436c57124202b5b5ccd6366e5d8e75eeb184cf078c826e8d/debugpy-1.8.18-py2.py3-none-any.whl
   name: debugpy
   version: 1.8.18
@@ -1974,6 +2519,116 @@ packages:
   - pytest-benchmark ; extra == 'devel'
   - pytest-cache ; extra == 'devel'
   - validictory ; extra == 'devel'
+- pypi: https://files.pythonhosted.org/packages/f0/cc/3b7408b8ecf7c1d20ad480c3eaed7619857bf1054b690226e906fdf14258/ffmpeg-1.4.tar.gz
+  name: ffmpeg
+  version: '1.4'
+  sha256: 6931692c890ff21d39938433c2189747815dca0c60ddc7f9bb97f199dba0b5b9
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-8.0.1-gpl_h43fde53_912.conda
+  sha256: ace426e0372a8cea862ada112336fe04b5445f21e761c7042a33ec5900258af6
+  md5: c1a58b1a35bc7e775f7fa61f4a2e8e75
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.15.3,<1.3.0a0
+  - aom >=3.9.1,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - gmp >=6.3.0,<7.0a0
+  - harfbuzz >=12.3.2
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.4,<0.17.5.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.2,<6.0a0
+  - libopenvino >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-auto-batch-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-auto-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-hetero-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-intel-cpu-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-intel-gpu-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-intel-npu-plugin >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-ir-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-onnx-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-paddle-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-pytorch-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-tensorflow-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopenvino-tensorflow-lite-frontend >=2025.4.1,<2025.4.2.0a0
+  - libopus >=1.6.1,<2.0a0
+  - librsvg >=2.60.0,<3.0a0
+  - libstdcxx >=14
+  - libva >=2.23.0,<3.0a0
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libvpl >=2.15.0,<2.16.0a0
+  - libvpx >=1.15.2,<1.16.0a0
+  - libvulkan-loader >=1.4.328.1,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.1,<2.0a0
+  - openh264 >=2.6.0,<2.6.1.0a0
+  - openssl >=3.5.5,<4.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - sdl2 >=2.32.56,<3.0a0
+  - shaderc >=2025.5,<2025.6.0a0
+  - svt-av1 >=4.0.1,<4.0.2.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  constrains:
+  - __cuda  >=12.8
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 12479894
+  timestamp: 1769713683312
+- conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-8.0.1-gpl_hb2d76f6_912.conda
+  sha256: 538967a0e7b0d34621c27999c90c4652a8bf0d2d01042a56071612b60f629371
+  md5: b60a9f146bd8f1f102aad1abd53e02eb
+  depends:
+  - aom >=3.9.1,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - harfbuzz >=12.3.2
+  - lame >=3.100,<3.101.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libiconv >=1.18,<2.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.2,<6.0a0
+  - libopus >=1.6.1,<2.0a0
+  - librsvg >=2.60.0,<3.0a0
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libvulkan-loader >=1.4.328.1,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libzlib >=1.3.1,<2.0a0
+  - openh264 >=2.6.0,<2.6.1.0a0
+  - openssl >=3.5.5,<4.0a0
+  - sdl2 >=2.32.56,<3.0a0
+  - shaderc >=2025.5,<2025.6.0a0
+  - svt-av1 >=4.0.1,<4.0.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  constrains:
+  - __cuda  >=12.8
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 10404974
+  timestamp: 1769715169641
 - pypi: https://files.pythonhosted.org/packages/d4/bb/38cb64a9f1e18f8f6caa6dc08951839f72d58dc5b8daed6b9a090fcd1764/fiat_toolbox-0.1.22-py3-none-any.whl
   name: fiat-toolbox
   version: 0.1.22
@@ -2068,13 +2723,66 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: flood-adapt
-  version: 1.1.4
-  sha256: 4b85fba9a459222bb01f0eec36ad75bc11dce60b7eb3b985f381d3aaafcb0f36
+  version: 2.0.3
+  sha256: ce00f023e7661e96afb676858160de9bd82b886712e3b98bcb3bb0583878f378
   requires_dist:
+  - cartopy
   - cht-cyclones>=1.0.3,<2.0
   - cht-meteo>=0.3.1,<1.0
   - cht-observations>=0.2.1,<1.0
   - cht-tide>=0.1.1,<1.0
+  - ffmpeg
+  - fiat-toolbox>=0.1.22,<0.2.0
+  - fiona>=1.0,<2.0
+  - geojson>=3.0,<4.0
+  - geopandas>=1.0,<2.0
+  - hydromt-fiat>=0.5.9,<1.0
+  - hydromt-sfincs[quadtree]>=1.2.2,<2.0
+  - numpy>=1.0,<2.0
+  - numpy-financial>=1.0,<2.0
+  - pandas>=2.0,<3.0
+  - plotly>=6.0,<6.3
+  - pydantic>=2.0,<3.0
+  - pydantic-settings>=2.0,<3.0
+  - pyogrio<1.0
+  - tomli>=2.0,<3.0
+  - tomli-w>=1.0,<2.0
+  - typing-extensions
+  - pytest>=8.0,<9.0 ; extra == 'dev'
+  - pytest-cov>=6.0,<7.0 ; extra == 'dev'
+  - pre-commit==3.8.0 ; extra == 'dev'
+  - ruff==0.5.5 ; extra == 'dev'
+  - typos==1.23.6 ; extra == 'dev'
+  - build>=1.2,<2.0 ; extra == 'build'
+  - twine>=6.0,<7.0 ; extra == 'build'
+  - pyinstaller==6.13.0 ; extra == 'build'
+  - pefile<2024.8.26 ; extra == 'build'
+  - jupyter>=1.0,<2.0 ; extra == 'docs'
+  - jupyter-cache>=1.0,<2.0 ; extra == 'docs'
+  - nbstripout>=0.8.0,<0.9 ; extra == 'docs'
+  - matplotlib>=3.0,<4.0 ; extra == 'docs'
+  - quartodoc>=0.9.0,<1.0 ; extra == 'docs'
+  - sphinx>=8.0,<9.0 ; extra == 'docs'
+  - sphinx-rtd-theme>=3.0,<4.0 ; extra == 'docs'
+  - regex>=2024.11,<2025.0 ; extra == 'docs'
+  - minio>=7.2.15,<8 ; extra == 'docs'
+  - python-dotenv>=1.0,<2.0 ; extra == 'docs'
+  - folium>=0.19.0,<1.0 ; extra == 'docs'
+  - mapclassify>=2.8.0,<3.0 ; extra == 'docs'
+  - contextily ; extra == 'docs'
+  requires_python: '>=3.10,<3.13'
+  editable: true
+- pypi: ./
+  name: flood-adapt
+  version: 2.0.3
+  sha256: ce00f023e7661e96afb676858160de9bd82b886712e3b98bcb3bb0583878f378
+  requires_dist:
+  - cartopy
+  - cht-cyclones>=1.0.3,<2.0
+  - cht-meteo>=0.3.1,<1.0
+  - cht-observations>=0.2.1,<1.0
+  - cht-tide>=0.1.1,<1.0
+  - ffmpeg
   - fiat-toolbox>=0.1.22,<0.2.0
   - fiona>=1.0,<2.0
   - geojson>=3.0,<4.0
@@ -2126,6 +2834,92 @@ packages:
   - xyzservices
   - pytest ; extra == 'testing'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  md5: 0c96522c6bdaed4b1566d11387caaf45
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 397370
+  timestamp: 1566932522327
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  md5: 34893075a5c9e55cdafac56607368fc6
+  license: OFL-1.1
+  license_family: Other
+  purls: []
+  size: 96530
+  timestamp: 1620479909603
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  md5: 4d59c254e01d9cde7957100457e2d5fb
+  license: OFL-1.1
+  license_family: Other
+  purls: []
+  size: 700814
+  timestamp: 1620479612257
+- conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+  sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+  md5: 49023d73832ef61042f6a237cb2687e7
+  license: LicenseRef-Ubuntu-Font-Licence-Version-1.0
+  license_family: Other
+  purls: []
+  size: 1620504
+  timestamp: 1727511233259
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.15.0-h7e30c49_1.conda
+  sha256: 7093aa19d6df5ccb6ca50329ef8510c6acb6b0d8001191909397368b65b02113
+  md5: 8f5b0b297b59e1ac160ad4beec99dbee
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - freetype >=2.12.1,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 265599
+  timestamp: 1730283881107
+- conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.15.0-h765892d_1.conda
+  sha256: ed122fc858fb95768ca9ca77e73c8d9ddc21d4b2e13aaab5281e27593e840691
+  md5: 9bb0026a2131b09404c59c4290c697cd
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 192355
+  timestamp: 1730284147944
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  md5: fee5683a3f04bd15cbd8318b096a27ab
+  depends:
+  - fonts-conda-forge
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 3667
+  timestamp: 1566974674465
+- conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+  sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+  md5: a7970cd949a077b7cb9696379d338681
+  depends:
+  - font-ttf-ubuntu
+  - font-ttf-inconsolata
+  - font-ttf-dejavu-sans-mono
+  - font-ttf-source-code-pro
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 4059
+  timestamp: 1762351264405
 - pypi: https://files.pythonhosted.org/packages/29/a3/1fa90b95b690f0d7541f48850adc40e9019374d896c1b8148d15012b2458/fonttools-4.61.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
   name: fonttools
   version: 4.61.0
@@ -2269,6 +3063,47 @@ packages:
   requires_dist:
   - cached-property>=1.3.0 ; python_full_version < '3.8'
   requires_python: '>=2.7,!=3.0,!=3.1,!=3.2,!=3.3,!=3.4,<4'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.14.1-ha770c72_0.conda
+  sha256: bf8e4dffe46f7d25dc06f31038cacb01672c47b9f45201f065b0f4d00ab0a83e
+  md5: 4afc585cd97ba8a23809406cd8a9eda8
+  depends:
+  - libfreetype 2.14.1 ha770c72_0
+  - libfreetype6 2.14.1 h73754d4_0
+  license: GPL-2.0-only OR FTL
+  purls: []
+  size: 173114
+  timestamp: 1757945422243
+- conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.14.1-h57928b3_0.conda
+  sha256: a9b3313edea0bf14ea6147ea43a1059d0bf78771a1336d2c8282891efc57709a
+  md5: d69c21967f35eb2ce7f1f85d6b6022d3
+  depends:
+  - libfreetype 2.14.1 h57928b3_0
+  - libfreetype6 2.14.1 hdbac1cb_0
+  license: GPL-2.0-only OR FTL
+  purls: []
+  size: 184553
+  timestamp: 1757946164012
+- conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.16-hb03c661_0.conda
+  sha256: 858283ff33d4c033f4971bf440cebff217d5552a5222ba994c49be990dacd40d
+  md5: f9f81ea472684d75b9dd8d0b328cf655
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 61244
+  timestamp: 1757438574066
+- conda: https://conda.anaconda.org/conda-forge/win-64/fribidi-1.0.16-hfd05255_0.conda
+  sha256: 15011071ee56c216ffe276c8d734427f1f893f275ef733f728d13f610ed89e6e
+  md5: c27bd87e70f970010c1c6db104b88b18
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 64394
+  timestamp: 1757438741305
 - pypi: https://files.pythonhosted.org/packages/51/c7/b64cae5dba3a1b138d7123ec36bb5ccd39d39939f18454407e5468f4763f/fsspec-2025.12.0-py3-none-any.whl
   name: fsspec
   version: 2025.12.0
@@ -2376,6 +3211,40 @@ packages:
   - zstandard ; python_full_version < '3.14' and extra == 'test-full'
   - tqdm ; extra == 'tqdm'
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdk-pixbuf-2.44.5-h2b0a6b4_0.conda
+  sha256: bd61bc71e6a21f3d8e1a362310789fc329fd45eab3c66f1204249253f9abd3d0
+  md5: e3bcef76c3ecb25823c503ce11783d85
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libglib >=2.86.3,<3.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - liblzma >=5.8.2,<6.0a0
+  - libpng >=1.6.54,<1.7.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 575201
+  timestamp: 1769891110279
+- conda: https://conda.anaconda.org/conda-forge/win-64/gdk-pixbuf-2.44.5-h1f5b9c4_0.conda
+  sha256: 783513150c68fcf747ea6183afb76a73e94173f350684e56c45cc995f23ddeaa
+  md5: f85d7049a1e420fb5df3b885b851532e
+  depends:
+  - libglib >=2.86.3,<3.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libjpeg-turbo >=3.1.2,<4.0a0
+  - liblzma >=5.8.2,<6.0a0
+  - libpng >=1.6.54,<1.7.0a0
+  - libtiff >=4.7.1,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 572147
+  timestamp: 1769891293
 - pypi: https://files.pythonhosted.org/packages/31/b3/802576f2ea5dcb48501bb162e4c7b7b3ca5654a42b2c968ef98a797a4c79/geographiclib-2.1-py3-none-any.whl
   name: geographiclib
   version: '2.1'
@@ -2444,6 +3313,42 @@ packages:
   - requests>=2.16.2 ; extra == 'requests'
   - pytz ; extra == 'timezone'
   requires_python: '>=3.7'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/glslang-16.2.0-h96af755_1.conda
+  sha256: 88a5ad3571948bde22957d08ab01328b8a7eb04fdee66268b3125cc322dbde8b
+  md5: ba5b655d827f263090ad2dc514810328
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - spirv-tools >=2026,<2027.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1353008
+  timestamp: 1770195199411
+- conda: https://conda.anaconda.org/conda-forge/win-64/glslang-16.2.0-h294ba9c_1.conda
+  sha256: c46afa4a43b7709e07a69d0a2d70b10f59f22e96dbf9ec80e53a42cc6551111c
+  md5: 4b5f576265df0a05d4e47e48c50bb4e6
+  depends:
+  - spirv-tools >=2026,<2027.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 4929181
+  timestamp: 1770195251565
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-hac33072_2.conda
+  sha256: 309cf4f04fec0c31b6771a5809a1909b4b3154a2208f52351e1ada006f4c750c
+  md5: c94a5994ef49749880a8139cf9afcbe1
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  purls: []
+  size: 460055
+  timestamp: 1718980856608
 - pypi: https://files.pythonhosted.org/packages/0f/d6/77060dbd140c624e42ae3ece3df53b9d811000729a5c821b9fd671ceaac6/google_crc32c-1.7.1-cp312-cp312-win_amd64.whl
   name: google-crc32c
   version: 1.7.1
@@ -2460,6 +3365,30 @@ packages:
   - importlib-resources>=1.3 ; python_full_version < '3.9' and os_name == 'nt'
   - pytest ; extra == 'testing'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.14-hecca717_2.conda
+  sha256: 25ba37da5c39697a77fce2c9a15e48cf0a84f1464ad2aafbe53d8357a9f6cc8c
+  md5: 2cd94587f3a401ae05e03a6caf09539d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 99596
+  timestamp: 1755102025473
+- conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.14-hac47afa_2.conda
+  sha256: 5f1714b07252f885a62521b625898326ade6ca25fbc20727cfe9a88f68a54bfd
+  md5: b785694dd3ec77a011ccf0c24725382b
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  purls: []
+  size: 96336
+  timestamp: 1755102441729
 - pypi: https://files.pythonhosted.org/packages/6c/79/3912a94cf27ec503e51ba493692d6db1e3cd8ac7ac52b0b47c8e33d7f4f9/greenlet-3.3.0-cp312-cp312-win_amd64.whl
   name: greenlet
   version: 3.3.0
@@ -2497,6 +3426,46 @@ packages:
   version: 0.16.0
   sha256: 63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-12.3.2-h6083320_0.conda
+  sha256: 92015faf283f9c0a8109e2761042cd47ae7a4505e24af42a53bc3767cb249912
+  md5: d170a70fc1d5c605fcebdf16851bd54a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=78.2,<79.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libgcc >=14
+  - libglib >=2.86.3,<3.0a0
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 2035859
+  timestamp: 1769445400168
+- conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-12.3.2-h5a1b470_0.conda
+  sha256: f55c689dfb49a3778c2e3369a9103393f6cbd8efc9105753b8e081909dae74dd
+  md5: fb5d7b9527b418f83e3316f3e6daa8a2
+  depends:
+  - cairo >=1.18.4,<2.0a0
+  - graphite2 >=1.3.14,<2.0a0
+  - icu >=78.2,<79.0a0
+  - libexpat >=2.7.3,<3.0a0
+  - libfreetype >=2.14.1
+  - libfreetype6 >=2.14.1
+  - libglib >=2.86.3,<3.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1127522
+  timestamp: 1769445644521
 - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
   name: httpcore
   version: 1.0.9
@@ -2666,6 +3635,30 @@ packages:
   - pytest-cov ; extra == 'test'
   - pre-commit ; extra == 'test'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+  sha256: 142a722072fa96cf16ff98eaaf641f54ab84744af81754c292cb81e0881c0329
+  md5: 186a18e3ba246eccfc7cff00cd19a870
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 12728445
+  timestamp: 1767969922681
+- conda: https://conda.anaconda.org/conda-forge/win-64/icu-78.2-h637d24d_0.conda
+  sha256: 5a41fb28971342e293769fc968b3414253a2f8d9e30ed7c31517a15b4887246a
+  md5: 0ee3bb487600d5e71ab7d28951b2016a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 13222158
+  timestamp: 1767970128854
 - pypi: https://files.pythonhosted.org/packages/9f/cb/18326d2d89ad3b0dd143da971e77afd1e6ca6674f1b1c3df4b6bec6279fc/id-1.5.0-py3-none-any.whl
   name: id
   version: 1.5.0
@@ -2760,6 +3753,32 @@ packages:
   version: 2.3.0
   sha256: f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/intel-gmmlib-22.9.0-hb700be7_0.conda
+  sha256: edad668db79c6c4899d46e1cd4a331f5d008f9ed8f7d2e39e1dfe1a2d81acec0
+  md5: 26311c5112b5c713f472bdfbb5ec5aa3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 1009795
+  timestamp: 1765886047465
+- conda: https://conda.anaconda.org/conda-forge/linux-64/intel-media-driver-25.3.4-hecca717_0.conda
+  sha256: 286679d4c175e8db2d047be766d1629f1ea5828bff9fe7e6aac2e6f0fad2b427
+  md5: 7ae2034a0e2e24eb07468f1a50cdf0bb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - intel-gmmlib >=22.8.1,<23.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libva >=2.22.0,<3.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 8424610
+  timestamp: 1757591682198
 - pypi: https://files.pythonhosted.org/packages/32/4b/b99e37f88336009971405cbb7630610322ed6fbfa31e1d7ab3fbf3049a2d/invoke-2.2.1-py3-none-any.whl
   name: invoke
   version: 2.2.1
@@ -3446,6 +4465,28 @@ packages:
   version: 1.4.9
   sha256: f68208a520c3d86ea51acf688a3e3002615a7f0238002cccc17affecc86a8a54
   requires_python: '>=3.10'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+  sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
+  md5: a8832b479f93521a9e7b5b743803be51
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.0-only
+  license_family: LGPL
+  purls: []
+  size: 508258
+  timestamp: 1664996250081
+- conda: https://conda.anaconda.org/conda-forge/win-64/lame-3.100-hcfcfb64_1003.tar.bz2
+  sha256: 824988a396b97bb9138823a1b3aabd8326e06da5834b3011253d72bb45fd3a88
+  md5: d92e64077c44c9e32c72d4b5799d47e4
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: LGPL-2.0-only
+  license_family: LGPL
+  purls: []
+  size: 570583
+  timestamp: 1664996824680
 - pypi: https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl
   name: lark
   version: 1.3.1
@@ -3469,6 +4510,205 @@ packages:
   purls: []
   size: 725545
   timestamp: 1764007826689
+- conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
+  sha256: 412381a43d5ff9bbed82cd52a0bbca5b90623f62e41007c9c42d3870c60945ff
+  md5: 9344155d33912347b37f0ae6c410a835
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 264243
+  timestamp: 1745264221534
+- conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h6470a55_1.conda
+  sha256: 868a3dff758cc676fa1286d3f36c3e0101cca56730f7be531ab84dc91ec58e9d
+  md5: c1b81da6d29a14b542da14a36c9fbf3f
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 164701
+  timestamp: 1745264384716
+- conda: https://conda.anaconda.org/conda-forge/linux-64/level-zero-1.28.0-hb700be7_0.conda
+  sha256: 863e1caf9d0086f93b66c43bf646481bb820fffdf037425c511cb0a54d18d1fc
+  md5: a4724e93a90434575b889adb4dc57b49
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 672752
+  timestamp: 1770189828697
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20250512.1-cxx17_hba17884_0.conda
+  sha256: dcd1429a1782864c452057a6c5bc1860f2b637dc20a2b7e6eacd57395bbceff8
+  md5: 83b160d4da3e1e847bf044997621ed63
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  constrains:
+  - libabseil-static =20250512.1=cxx17*
+  - abseil-cpp =20250512.1
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1310612
+  timestamp: 1750194198254
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.4-h96ad9f0_0.conda
+  sha256: 035eb8b54e03e72e42ef707420f9979c7427776ea99e0f1e3c969f92eb573f19
+  md5: d3be7b2870bf7aff45b12ea53165babd
+  depends:
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - fribidi >=1.0.10,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - harfbuzz >=11.0.1
+  license: ISC
+  purls: []
+  size: 152179
+  timestamp: 1749328931930
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-hb03c661_1.conda
+  sha256: 318f36bd49ca8ad85e6478bd8506c88d82454cc008c1ac1c6bf00a3c42fa610e
+  md5: 72c8fd1af66bd67bf580645b426513ed
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 79965
+  timestamp: 1764017188531
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.2.0-hfd05255_1.conda
+  sha256: 5097303c2fc8ebf9f9ea9731520aa5ce4847d0be41764edd7f6dee2100b82986
+  md5: 444b0a45bbd1cb24f82eedb56721b9c4
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 82042
+  timestamp: 1764017799966
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-hb03c661_1.conda
+  sha256: 12fff21d38f98bc446d82baa890e01fd82e3b750378fedc720ff93522ffb752b
+  md5: 366b40a69f0ad6072561c1d09301c886
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.2.0 hb03c661_1
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 34632
+  timestamp: 1764017199083
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.2.0-hfd05255_1.conda
+  sha256: 3239ce545cf1c32af6fffb7fc7c75cb1ef5b6ea8221c66c85416bb2d46f5cccb
+  md5: 450e3ae947fc46b60f1d8f8f318b40d4
+  depends:
+  - libbrotlicommon 1.2.0 hfd05255_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 34449
+  timestamp: 1764017851337
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-hb03c661_1.conda
+  sha256: a0c15c79997820bbd3fbc8ecf146f4fe0eca36cc60b62b63ac6cf78857f1dd0d
+  md5: 4ffbb341c8b616aa2494b6afb26a0c5f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libbrotlicommon 1.2.0 hb03c661_1
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 298378
+  timestamp: 1764017210931
+- conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.2.0-hfd05255_1.conda
+  sha256: 3226df6b7df98734440739f75527d585d42ca2bfe912fbe8d1954c512f75341a
+  md5: ccd93cfa8e54fd9df4e83dbe55ff6e8c
+  depends:
+  - libbrotlicommon 1.2.0 hfd05255_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 252903
+  timestamp: 1764017901735
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.77-h3ff7636_0.conda
+  sha256: 9517cce5193144af0fcbf19b7bd67db0a329c2cc2618f28ffecaa921a1cbe9d3
+  md5: 09c264d40c67b82b49a3f3b89037bd2e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - attr >=2.5.2,<2.6.0a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 121429
+  timestamp: 1762349484074
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-h17f619e_0.conda
+  sha256: aa8e8c4be9a2e81610ddf574e05b64ee131fab5e0e3693210c9d6d2fba32c680
+  md5: 6c77a605a7a689d17d4819c0f8ac9a00
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 73490
+  timestamp: 1761979956660
+- conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h51727cc_0.conda
+  sha256: 834e4881a18b690d5ec36f44852facd38e13afe599e369be62d29bd675f107ee
+  md5: e77030e67343e28b084fabd7db0ce43e
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 156818
+  timestamp: 1761979842440
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.125-hb03c661_1.conda
+  sha256: c076a213bd3676cc1ef22eeff91588826273513ccc6040d9bea68bccdc849501
+  md5: 9314bc5a1fe7d1044dc9dfd3ef400535
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libpciaccess >=0.18,<0.19.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 310785
+  timestamp: 1757212153962
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libegl-1.7.0-ha4b6fd6_2.conda
+  sha256: 7fd5408d359d05a969133e47af580183fbf38e2235b562193d427bb9dad79723
+  md5: c151d5eb730e9b7480e6d48c0fc44048
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 44840
+  timestamp: 1731330973553
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.3-hecca717_0.conda
   sha256: 1e1b08f6211629cbc2efe7a5bca5953f8f6b3cae0eeb04ca4dacee1bd4e2db2f
   md5: 8b09ae86839581147ef2e5c5e229d164
@@ -3519,6 +4759,67 @@ packages:
   purls: []
   size: 44866
   timestamp: 1760295760649
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.5.0-he200343_1.conda
+  sha256: e755e234236bdda3d265ae82e5b0581d259a9279e3e5b31d745dc43251ad64fb
+  md5: 47595b9d53054907a00d95e4d47af1d6
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - libogg >=1.3.5,<1.4.0a0
+  - libstdcxx >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 424563
+  timestamp: 1764526740626
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.1-ha770c72_0.conda
+  sha256: 4641d37faeb97cf8a121efafd6afd040904d4bca8c46798122f417c31d5dfbec
+  md5: f4084e4e6577797150f9b04a4560ceb0
+  depends:
+  - libfreetype6 >=2.14.1
+  license: GPL-2.0-only OR FTL
+  purls: []
+  size: 7664
+  timestamp: 1757945417134
+- conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype-2.14.1-h57928b3_0.conda
+  sha256: 2029702ec55e968ce18ec38cc8cf29f4c8c4989a0d51797164dab4f794349a64
+  md5: 3235024fe48d4087721797ebd6c9d28c
+  depends:
+  - libfreetype6 >=2.14.1
+  license: GPL-2.0-only OR FTL
+  purls: []
+  size: 8109
+  timestamp: 1757946135015
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.1-h73754d4_0.conda
+  sha256: 4a7af818a3179fafb6c91111752954e29d3a2a950259c14a2fc7ba40a8b03652
+  md5: 8e7251989bca326a28f4a5ffbd74557a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libpng >=1.6.50,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - freetype >=2.14.1
+  license: GPL-2.0-only OR FTL
+  purls: []
+  size: 386739
+  timestamp: 1757945416744
+- conda: https://conda.anaconda.org/conda-forge/win-64/libfreetype6-2.14.1-hdbac1cb_0.conda
+  sha256: 223710600b1a5567163f7d66545817f2f144e4ef8f84e99e90f6b8a4e19cb7ad
+  md5: 6e7c5c5ab485057b5d07fd8188ba5c28
+  depends:
+  - libpng >=1.6.50,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - freetype >=2.14.1
+  license: GPL-2.0-only OR FTL
+  purls: []
+  size: 340264
+  timestamp: 1757946133889
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_16.conda
   sha256: 6eed58051c2e12b804d53ceff5994a350c61baf117ec83f5f10c953a3f311451
   md5: 6d0363467e6ed84f11435eb309f2ff06
@@ -3541,6 +4842,71 @@ packages:
   purls: []
   size: 27256
   timestamp: 1765256804124
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgl-1.7.0-ha4b6fd6_2.conda
+  sha256: dc2752241fa3d9e40ce552c1942d0a4b5eeb93740c9723873f6fcf8d39ef8d2d
+  md5: 928b8be80851f5d8ffb016f9c81dae7a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  - libglx 1.7.0 ha4b6fd6_2
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 134712
+  timestamp: 1731330998354
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.86.3-h6548e54_0.conda
+  sha256: 82d6c2ee9f548c84220fb30fb1b231c64a53561d6e485447394f0a0eeeffe0e6
+  md5: 034bea55a4feef51c98e8449938e9cee
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  constrains:
+  - glib 2.86.3 *_0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 3946542
+  timestamp: 1765221858705
+- conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.86.3-h0c9aed9_0.conda
+  sha256: 84b74fc81fff745f3d21a26c317ace44269a563a42ead3500034c27e407e1021
+  md5: c2d5b6b790ef21abac0b5331094ccb56
+  depends:
+  - libffi >=3.5.2,<3.6.0a0
+  - libiconv >=1.18,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - glib 2.86.3 *_0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 3818991
+  timestamp: 1765222145992
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglvnd-1.7.0-ha4b6fd6_2.conda
+  sha256: 1175f8a7a0c68b7f81962699751bb6574e6f07db4c9f72825f978e3016f46850
+  md5: 434ca7e50e40f4918ab701e3facd59a0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 132463
+  timestamp: 1731330968309
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libglx-1.7.0-ha4b6fd6_2.conda
+  sha256: 2d35a679624a93ce5b3e9dd301fff92343db609b79f0363e6d0ceb3a6478bfa7
+  md5: c8013e438185f33b13814c5c488acd5c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libglvnd 1.7.0 ha4b6fd6_2
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: LicenseRef-libglvnd
+  purls: []
+  size: 75504
+  timestamp: 1731330988898
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_16.conda
   sha256: 5b3e5e4e9270ecfcd48f47e3a68f037f5ab0f529ccb223e8e5d5ac75a58fc687
   md5: 26c46f90d0e727e95c6c9498a33a09f3
@@ -3550,31 +4916,152 @@ packages:
   purls: []
   size: 603284
   timestamp: 1765256703881
-- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
-  sha256: f2591c0069447bbe28d4d696b7fcb0c5bd0b4ac582769b89addbcf26fb3430d8
-  md5: 1a580f7796c7bf6393fddb8bbbde58dc
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.12.2-default_hafda6a7_1000.conda
+  sha256: 2cf160794dda62cf93539adf16d26cfd31092829f2a2757dbdd562984c1b110a
+  md5: 0ed3aa3e3e6bc85050d38881673a692f
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  constrains:
-  - xz 5.8.1.*
-  license: 0BSD
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxml2
+  - libxml2-16 >=2.14.6
+  license: BSD-3-Clause
+  license_family: BSD
   purls: []
-  size: 112894
-  timestamp: 1749230047870
-- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.1-h2466b09_2.conda
-  sha256: 55764956eb9179b98de7cc0e55696f2eff8f7b83fc3ebff5e696ca358bca28cc
-  md5: c15148b2e18da456f5108ccb5e411446
+  size: 2449916
+  timestamp: 1765103845133
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libhwy-1.3.0-h4c17acf_1.conda
+  sha256: 2bdd1cdd677b119abc5e83069bec2e28fe6bfb21ebaea3cd07acee67f38ea274
+  md5: c2a0c1d0120520e979685034e0b79859
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: Apache-2.0 OR BSD-3-Clause
+  purls: []
+  size: 1448617
+  timestamp: 1758894401402
+- conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.3.0-ha71e874_1.conda
+  sha256: c722a04f065656b988a46dee87303ff0bf037179c50e2e76704b693def7f9a96
+  md5: f4649d4b6bf40d616eda57d6255d2333
   depends:
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0 OR BSD-3-Clause
+  purls: []
+  size: 536186
+  timestamp: 1758894243956
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h3b78370_2.conda
+  sha256: c467851a7312765447155e071752d7bf9bf44d610a5687e32706f480aad2833f
+  md5: 915f5995e94f60e9a4826e0b0920ee88
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LGPL-2.1-only
+  purls: []
+  size: 790176
+  timestamp: 1754908768807
+- conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
+  sha256: 0dcdb1a5f01863ac4e8ba006a8b0dc1a02d2221ec3319b5915a1863254d7efa7
+  md5: 64571d1dd6cdcfa25d0664a5950fdaa2
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-2.1-only
+  purls: []
+  size: 696926
+  timestamp: 1754909290005
+- conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_3.conda
+  sha256: c7e4600f28bcada8ea81456a6530c2329312519efcf0c886030ada38976b0511
+  md5: 2cf0cf76cc15d360dfa2f17fd6cf9772
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 95568
+  timestamp: 1723629479451
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.2-hb03c661_0.conda
+  sha256: cc9aba923eea0af8e30e0f94f2ad7156e2984d80d1e8e7fe6be5a1f257f0eb32
+  md5: 8397539e3a0bbd1695584fb4f927485a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
   constrains:
-  - xz 5.8.1.*
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
+  size: 633710
+  timestamp: 1762094827865
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.1.2-hfd05255_0.conda
+  sha256: 795e2d4feb2f7fc4a2c6e921871575feb32b8082b5760726791f080d1e2c2597
+  md5: 56a686f92ac0273c0f6af58858a3f013
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - jpeg <0.0.0a
+  license: IJG AND BSD-3-Clause AND Zlib
+  purls: []
+  size: 841783
+  timestamp: 1762094814336
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libjxl-0.11.2-ha09017c_0.conda
+  sha256: 0c2399cef02953b719afe6591223fb11d287d5a108ef8bb9a02dd509a0f738d7
+  md5: 1df8c1b1d6665642107883685db6cf37
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libhwy >=1.3.0,<1.4.0a0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1883476
+  timestamp: 1770801977654
+- conda: https://conda.anaconda.org/conda-forge/win-64/libjxl-0.11.2-hf3f85d1_0.conda
+  sha256: 525c5382eb32a43e7baf45b452079bf23daf8f8bf19fee7c8dafa8c731ada8bd
+  md5: 869e71fcf2135212c51a96f7f7dbd00d
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libbrotlienc >=1.2.0,<1.3.0a0
+  - libbrotlidec >=1.2.0,<1.3.0a0
+  - libhwy >=1.3.0,<1.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1317916
+  timestamp: 1770801992810
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+  sha256: 755c55ebab181d678c12e49cced893598f2bab22d582fbbf4d8b83c18be207eb
+  md5: c7c83eecbb72d88b940c249af56c8b17
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - xz 5.8.2.*
   license: 0BSD
   purls: []
-  size: 104935
-  timestamp: 1749230611612
+  size: 113207
+  timestamp: 1768752626120
+- conda: https://conda.anaconda.org/conda-forge/win-64/liblzma-5.8.2-hfd05255_0.conda
+  sha256: f25bf293f550c8ed2e0c7145eb404324611cfccff37660869d97abf526eb957c
+  md5: ba0bfd4c3cf73f299ffe46ff0eaeb8e3
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - xz 5.8.2.*
+  license: 0BSD
+  purls: []
+  size: 106169
+  timestamp: 1768752763559
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hb9d3cd8_1.conda
   sha256: 927fe72b054277cde6cb82597d0fcf6baf127dcbce2e0a9d8925a68f1265eef5
   md5: d864d34357c3b65a4b731f78c0801dc4
@@ -3586,6 +5073,321 @@ packages:
   purls: []
   size: 33731
   timestamp: 1750274110928
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.5-hd0c01bc_1.conda
+  sha256: ffb066ddf2e76953f92e06677021c73c85536098f1c21fcd15360dbc859e22e4
+  md5: 68e52064ed3897463c0e958ab5c8f91b
+  depends:
+  - libgcc >=13
+  - __glibc >=2.17,<3.0.a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 218500
+  timestamp: 1745825989535
+- conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.5-h2466b09_1.conda
+  sha256: c63e5fb169dbd192aacdcee6e37235407f106b8ca9c9036942a25e0366cbc73c
+  md5: b67ed8c9ca072695ff482e50d888a523
+  depends:
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - ucrt >=10.0.20348.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 35040
+  timestamp: 1745826086628
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2025.4.1-hb56ce9e_1.conda
+  sha256: d85e5e3b6dc56d6fdfe0c51a8af92407a7ef4fc5584d0e172d059033b8d6d3e0
+  md5: 9c4a59b80f7fc8da96bb807db95be69c
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2022.3.0
+  purls: []
+  size: 6504144
+  timestamp: 1769904250547
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2025.4.1-hd85de46_1.conda
+  sha256: 7ec8faf6b4541f098b5c5c399b971075a1cca0a9bec19aa4ed4e70a88026496c
+  md5: 937020cf4502334abd149c0393d1f50e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_1
+  - libstdcxx >=14
+  - tbb >=2022.3.0
+  purls: []
+  size: 114792
+  timestamp: 1769904275716
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2025.4.1-hd85de46_1.conda
+  sha256: aee3ae9d91a098263023fc2cb4b2d1e58a7111984c6503ae6e7c8e1169338f02
+  md5: d6e354f426f1a7a818a5ddcd930eec32
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_1
+  - libstdcxx >=14
+  - tbb >=2022.3.0
+  purls: []
+  size: 250114
+  timestamp: 1769904292210
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2025.4.1-hd41364c_1.conda
+  sha256: bcf3d31a2bcc666b848506fb52b2979a28d7035e9942d39121d4ea64a27bfbfb
+  md5: 4fc70db8bc65b02ee9f0af2b76c7fa11
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_1
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  purls: []
+  size: 212030
+  timestamp: 1769904308850
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2025.4.1-hb56ce9e_1.conda
+  sha256: 0ce2e257c87076aff0a19f4b9bb79a40fcfea04090e66b2f960cb341b9860c8e
+  md5: 2b9d3633dd182fa09a4ee935d841e0cb
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_1
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2022.3.0
+  purls: []
+  size: 12956806
+  timestamp: 1769904325853
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2025.4.1-hb56ce9e_1.conda
+  sha256: ca1981eb418551a6dbf0ab754a2b7297aae1131e36cde9001862ffdf23625f9d
+  md5: 1d2c0d22a6e2da0f7bcab32e9fe685d3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_1
+  - libstdcxx >=14
+  - ocl-icd >=2.3.3,<3.0a0
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2022.3.0
+  purls: []
+  size: 11421657
+  timestamp: 1769904366195
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-npu-plugin-2025.4.1-hb56ce9e_1.conda
+  sha256: 0b3bb86bceb8f5f0d074c26f697e3dfc638f5886754d31252db3aff8a1608e82
+  md5: feb5d4c644bba35147fbcf375a4962ed
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - level-zero >=1.27.0,<2.0a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_1
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  - tbb >=2022.3.0
+  purls: []
+  size: 1743490
+  timestamp: 1769904403110
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2025.4.1-hd41364c_1.conda
+  sha256: 124df6a82752ac14b7d08a4345be7a5d7295183e7f76a7960af97e0b869d754d
+  md5: 07d4163e2859d645d065f2a627d5595a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_1
+  - libstdcxx >=14
+  - pugixml >=1.15,<1.16.0a0
+  purls: []
+  size: 200411
+  timestamp: 1769904421156
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2025.4.1-h1862bb8_1.conda
+  sha256: 22faa2b16c13558c3e245f12deffca6f89e22752dd0135c0826fbbeb43e90603
+  md5: 195f9d73c2ca55de60846d8bd274cf41
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20250512.1,<20250513.0a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_1
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libstdcxx >=14
+  purls: []
+  size: 1902792
+  timestamp: 1769904438153
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2025.4.1-h1862bb8_1.conda
+  sha256: f03aba53f64b0e2dae1989f9ff680fdc955d087424e1e00c34f3436815c49f18
+  md5: 0ccbdeaf77b0dc8b09cbacd756c2250f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20250512.1,<20250513.0a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_1
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libstdcxx >=14
+  purls: []
+  size: 745483
+  timestamp: 1769904456844
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2025.4.1-hecca717_1.conda
+  sha256: 5edd997be35bbdda6c8916de46a4ae7f321af6a6b07ba136228404cb713bcbe9
+  md5: 8d6450b5a6a5c33439a38b954511eb45
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_1
+  - libstdcxx >=14
+  purls: []
+  size: 1266512
+  timestamp: 1769904473901
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2025.4.1-h0767aad_1.conda
+  sha256: 15aa71394abf35d3a25d2d8f68e419f9dbbc57a0849bc1f8ae34589b77f96aa7
+  md5: 9de5caa2cccb13b7bb765a915edb5aa8
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20250512.1,<20250513.0a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_1
+  - libprotobuf >=6.31.1,<6.31.2.0a0
+  - libstdcxx >=14
+  - snappy >=1.2.2,<1.3.0a0
+  purls: []
+  size: 1324086
+  timestamp: 1769904491964
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2025.4.1-hecca717_1.conda
+  sha256: 13d8f823cd137bcfa7830c13e114e43288b4d43f5d599c4bec3e8f9d07233a29
+  md5: 1a9afdd2b66ba2da54b31298d63e352e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libopenvino 2025.4.1 hb56ce9e_1
+  - libstdcxx >=14
+  purls: []
+  size: 496261
+  timestamp: 1769904509651
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.6.1-h280c20c_0.conda
+  sha256: f1061a26213b9653bbb8372bfa3f291787ca091a9a3060a10df4d5297aad74fd
+  md5: 2446ac1fe030c2aa6141386c1f5a6aed
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 324993
+  timestamp: 1768497114401
+- conda: https://conda.anaconda.org/conda-forge/win-64/libopus-1.6.1-h6a83c73_0.conda
+  sha256: c3678f111866235b44fa65265966abae7d90b6387178f1459afaedcee8b4a997
+  md5: 0ed21da5b6e3a0393e05762b3cce2878
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 307373
+  timestamp: 1768497136248
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hb9d3cd8_0.conda
+  sha256: 0bd91de9b447a2991e666f284ae8c722ffb1d84acb594dbd0c031bd656fa32b2
+  md5: 70e3400cbbfa03e96dcde7fc13e38c7b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 28424
+  timestamp: 1749901812541
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.55-h421ea60_0.conda
+  sha256: 36ade759122cdf0f16e2a2562a19746d96cf9c863ffaa812f2f5071ebbe9c03c
+  md5: 5f13ffc7d30ffec87864e678df9957b4
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  purls: []
+  size: 317669
+  timestamp: 1770691470744
+- conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.55-h7351971_0.conda
+  sha256: db23f281fa80597a0dc0445b18318346862602d7081ed76244df8cc4418d6d68
+  md5: 43f47a9151b9b8fc100aeefcf350d1a0
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libzlib >=1.3.1,<2.0a0
+  license: zlib-acknowledgement
+  purls: []
+  size: 383155
+  timestamp: 1770691504832
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.31.1-h49aed37_4.conda
+  sha256: 0ef142ac31e6fd59b4af89ac800acb6deb3fbd9cc4ccf070c03cc2c784dc7296
+  md5: 07479fc04ba3ddd5d9f760ef1635cfa7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libabseil * cxx17*
+  - libabseil >=20250512.1,<20250513.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 4372578
+  timestamp: 1766316228461
+- conda: https://conda.anaconda.org/conda-forge/linux-64/librsvg-2.60.0-h61e6d4b_0.conda
+  sha256: 960b137673b2b8293e2a12d194add72967b3bf12fcdf691e7ad8bd5c8318cec3
+  md5: 91e6d4d684e237fba31b9815c4b40edf
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - gdk-pixbuf >=2.44.3,<3.0a0
+  - libgcc >=14
+  - libglib >=2.86.0,<3.0a0
+  - libxml2-16 >=2.14.6
+  - pango >=1.56.4,<2.0a0
+  constrains:
+  - __glibc >=2.17
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 3421977
+  timestamp: 1759327942156
+- conda: https://conda.anaconda.org/conda-forge/win-64/librsvg-2.60.0-hd5e4115_0.conda
+  sha256: a0e8d89c36e555149f3ba2d58bb96f1b77e8ed7924db8a242ee0b0fb613c588d
+  md5: 5b38f886aa0548d6f6f5d1a30b3ae0ca
+  depends:
+  - cairo >=1.18.4,<2.0a0
+  - gdk-pixbuf >=2.44.3,<3.0a0
+  - libglib >=2.86.0,<3.0a0
+  - libxml2-16 >=2.14.6
+  - pango >=1.56.4,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 3336793
+  timestamp: 1759328441569
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc7d488a_2.conda
+  sha256: 57cb5f92110324c04498b96563211a1bca6a74b2918b1e8df578bfed03cc32e4
+  md5: 067590f061c9f6ea7e61e3b2112ed6b3
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lame >=3.100,<3.101.0a0
+  - libflac >=1.5.0,<1.6.0a0
+  - libgcc >=14
+  - libogg >=1.3.5,<1.4.0a0
+  - libopus >=1.5.2,<2.0a0
+  - libstdcxx >=14
+  - libvorbis >=1.3.7,<1.4.0a0
+  - mpg123 >=1.32.9,<1.33.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 355619
+  timestamp: 1765181778282
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.1-h0c1763c_0.conda
   sha256: 6f0e8a812e8e33a4d8b7a0e595efe28373080d27b78ee4828aa4f6649a088454
   md5: 2e1b84d273b01835256e53fd938de355
@@ -3608,6 +5410,135 @@ packages:
   purls: []
   size: 1291059
   timestamp: 1764359545703
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
+  sha256: 813427918316a00c904723f1dfc3da1bbc1974c5cfe1ed1e704c6f4e0798cbc6
+  md5: 68f68355000ec3f1d6f26ea13e8f525f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc 15.2.0 he0feb66_16
+  constrains:
+  - libstdcxx-ng ==15.2.0=*_16
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 5856456
+  timestamp: 1765256838573
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.2.0-hdf11a46_16.conda
+  sha256: 81f2f246c7533b41c5e0c274172d607829019621c4a0823b5c0b4a8c7028ee84
+  md5: 1b3152694d236cf233b76b8c56bf0eae
+  depends:
+  - libstdcxx 15.2.0 h934c35e_16
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  purls: []
+  size: 27300
+  timestamp: 1765256885128
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-257.10-hd0affe5_4.conda
+  sha256: f0356bb344a684e7616fc84675cfca6401140320594e8686be30e8ac7547aed2
+  md5: 1d4c18d75c51ed9d00092a891a547a7d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.77,<2.78.0a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 491953
+  timestamp: 1770738638119
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.1-h9d88235_1.conda
+  sha256: e5f8c38625aa6d567809733ae04bb71c161a42e44a9fa8227abe61fa5c60ebe0
+  md5: cd5a90476766d53e901500df9215e927
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libgcc >=14
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libstdcxx >=14
+  - libwebp-base >=1.6.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  purls: []
+  size: 435273
+  timestamp: 1762022005702
+- conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.7.1-h8f73337_1.conda
+  sha256: f1b8cccaaeea38a28b9cd496694b2e3d372bb5be0e9377c9e3d14b330d1cba8a
+  md5: 549845d5133100142452812feb9ba2e8
+  depends:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libjpeg-turbo >=3.1.0,<4.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  license: HPND
+  purls: []
+  size: 993166
+  timestamp: 1762022118895
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libudev1-257.10-hd0affe5_4.conda
+  sha256: ed4d2c01fbeb1330f112f7e399408634db277d3dfb2dec1d0395f56feaa24351
+  md5: 6c74fba677b61a0842cbf0f63eee683b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.77,<2.78.0a0
+  - libgcc >=14
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 144654
+  timestamp: 1770738650966
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libunwind-1.8.3-h65a8314_0.conda
+  sha256: 71c8b9d5c72473752a0bb6e91b01dd209a03916cb71f36cc6a564e3a2a132d7a
+  md5: e179a69edd30d75c0144d7a380b88f28
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 75995
+  timestamp: 1757032240102
+- conda: https://conda.anaconda.org/conda-forge/linux-64/liburing-2.13-hb700be7_0.conda
+  sha256: 5e4863d8cc9ccba7884f68d5b3c4b4f44a5a836ad7d3b332ac9aaaef0c0b9d45
+  md5: 60adb61326a4a0072ed238f460b02029
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 132334
+  timestamp: 1765872504784
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libusb-1.0.29-h73b1eb8_0.conda
+  sha256: 89c84f5b26028a9d0f5c4014330703e7dff73ba0c98f90103e9cef6b43a5323c
+  md5: d17e3fb595a9f24fa9e149239a33475d
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libudev1 >=257.4
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 89551
+  timestamp: 1748856210075
+- conda: https://conda.anaconda.org/conda-forge/win-64/libusb-1.0.29-h1839187_0.conda
+  sha256: 9837f8e8de20b6c9c033561cd33b4554cd551b217e3b8d2862b353ed2c23d8b8
+  md5: a656b2c367405cd24988cf67ff2675aa
+  depends:
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - ucrt >=10.0.20348.0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 118204
+  timestamp: 1748856290542
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.2-h5347b49_1.conda
   sha256: 030447cf827c471abd37092ab9714fde82b8222106f22fde94bc7a64e2704c40
   md5: 41f5c09a211985c3ce642d60721e7c3e
@@ -3619,6 +5550,157 @@ packages:
   purls: []
   size: 40235
   timestamp: 1764790744114
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.23.0-he1eb515_0.conda
+  sha256: 255c7d00b54e26f19fad9340db080716bced1d8539606e2b8396c57abd40007c
+  md5: 25813fe38b3e541fc40007592f12bae5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libdrm >=2.4.125,<2.5.0a0
+  - libegl >=1.7.0,<2.0a0
+  - libgcc >=14
+  - libgl >=1.7.0,<2.0a0
+  - libglx >=1.7.0,<2.0a0
+  - libxcb >=1.17.0,<2.0a0
+  - wayland >=1.24.0,<2.0a0
+  - wayland-protocols
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 221308
+  timestamp: 1765652453244
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h54a6638_2.conda
+  sha256: ca494c99c7e5ecc1b4cd2f72b5584cef3d4ce631d23511184411abcbb90a21a5
+  md5: b4ecbefe517ed0157c37f8182768271c
+  depends:
+  - libogg
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - libogg >=1.3.5,<1.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 285894
+  timestamp: 1753879378005
+- conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h5112557_2.conda
+  sha256: 429124709c73b2e8fae5570bdc6b42f5418a7551ba72e591bb960b752e87b365
+  md5: 42a8a56c60882da5d451aa95b8455111
+  depends:
+  - libogg
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libogg >=1.3.5,<1.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 243401
+  timestamp: 1753879416570
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpl-2.15.0-h54a6638_1.conda
+  sha256: bf0010d93f5b154c59bd9d3cc32168698c1d24f2904729f4693917cce5b27a9f
+  md5: a41a299c157cc6d0eff05e5fc298cc45
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - intel-media-driver >=25.3.3,<25.4.0a0
+  - libva >=2.22.0,<3.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 287944
+  timestamp: 1757278954789
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.15.2-hecca717_0.conda
+  sha256: 8e1119977f235b488ab32d540c018d3fd1eccefc3dd3859921a0ff555d8c10d2
+  md5: 10f5008f1c89a40b09711b5a9cdbd229
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1070048
+  timestamp: 1762010217363
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libvulkan-loader-1.4.341.0-h5279c79_0.conda
+  sha256: a68280d57dfd29e3d53400409a39d67c4b9515097eba733aa6fe00c880620e2b
+  md5: 31ad065eda3c2d88f8215b1289df9c89
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxrandr >=1.5.5,<2.0a0
+  constrains:
+  - libvulkan-headers 1.4.341.0.*
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 199795
+  timestamp: 1770077125520
+- conda: https://conda.anaconda.org/conda-forge/win-64/libvulkan-loader-1.4.341.0-h477610d_0.conda
+  sha256: 0f0965edca8b255187604fc7712c53fe9064b31a1845a7dfb2b63bf660de84a7
+  md5: 804880b2674119b84277d6c16b01677d
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  constrains:
+  - libvulkan-headers 1.4.341.0.*
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 282251
+  timestamp: 1770077165680
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_0.conda
+  sha256: 3aed21ab28eddffdaf7f804f49be7a7d701e8f0e46c856d801270b470820a37b
+  md5: aea31d2e5b1091feca96fcfe945c3cf9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 429011
+  timestamp: 1752159441324
+- conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.6.0-h4d5522a_0.conda
+  sha256: 7b6316abfea1007e100922760e9b8c820d6fc19df3f42fb5aca684cfacb31843
+  md5: f9bbae5e2537e3b06e0f7310ba76c893
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - libwebp 1.6.0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 279176
+  timestamp: 1752159543911
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
+  sha256: 666c0c431b23c6cec6e492840b176dde533d48b7e6fb8883f5071223433776aa
+  md5: 92ed62436b625154323d40d5f2f11dd7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 395888
+  timestamp: 1727278577118
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
   sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
   md5: 5aa797f8787fe7a17d1b0821485b5adc
@@ -3628,6 +5710,91 @@ packages:
   purls: []
   size: 100393
   timestamp: 1702724383534
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.13.1-hca5e8e5_0.conda
+  sha256: d2195b5fbcb0af1ff7b345efdf89290c279b8d1d74f325ae0ac98148c375863c
+  md5: 2bca1fbb221d9c3c8e3a155784bbc2e9
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libxcb >=1.17.0,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - xkeyboard-config
+  - xorg-libxau >=1.0.12,<2.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  purls: []
+  size: 837922
+  timestamp: 1764794163823
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.1-he237659_1.conda
+  sha256: 047be059033c394bd32ae5de66ce389824352120b3a7c0eff980195f7ed80357
+  md5: 417955234eccd8f252b86a265ccdab7f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.1,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.1 hca6bf5a_1
+  - libzlib >=1.3.1,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 45402
+  timestamp: 1766327161688
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.15.1-h779ef1b_1.conda
+  sha256: 8b47d5fb00a6ccc0f495d16787ab5f37a434d51965584d6000966252efecf56d
+  md5: 68dc154b8d415176c07b6995bd3a65d9
+  depends:
+  - icu >=78.1,<79.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libxml2-16 2.15.1 h3cfd58e_1
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 43387
+  timestamp: 1766327259710
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.1-hca6bf5a_1.conda
+  sha256: 8331284bf9ae641b70cdc0e5866502dd80055fc3b9350979c74bb1d192e8e09e
+  md5: 3fdd8d99683da9fe279c2f4cecd1e048
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - icu >=78.1,<79.0a0
+  - libgcc >=14
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  constrains:
+  - libxml2 2.15.1
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 555747
+  timestamp: 1766327145986
+- conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-16-2.15.1-h3cfd58e_1.conda
+  sha256: a857e941156b7f462063e34e086d212c6ccbc1521ebdf75b9ed66bd90add57dc
+  md5: 07d73826fde28e7dbaec52a3297d7d26
+  depends:
+  - icu >=78.1,<79.0a0
+  - libiconv >=1.18,<2.0a0
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - libxml2 2.15.1
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 518964
+  timestamp: 1766327232819
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
   sha256: d4bfe88d7cb447768e31650f06257995601f89076080e76df55e3112d4e47dc4
   md5: edb0dca6bc32e4f4789199455a1dbeb8
@@ -3906,6 +6073,18 @@ packages:
   version: 10.8.0
   sha256: 52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.9-hc50e24c_0.conda
+  sha256: 39c4700fb3fbe403a77d8cc27352fa72ba744db487559d5d44bf8411bb4ea200
+  md5: c7f302fd11eeb0987a6a5e1f3aed6a21
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: LGPL-2.1-only
+  license_family: LGPL
+  purls: []
+  size: 491140
+  timestamp: 1730581373280
 - pypi: https://files.pythonhosted.org/packages/51/c0/00c9809d8b9346eb238a6bbd5f83e846a4ce4503da94a4c08cb7284c325b/multipledispatch-1.0.0-py3-none-any.whl
   name: multipledispatch
   version: 1.0.0
@@ -4305,6 +6484,54 @@ packages:
   requires_dist:
   - numpy>=1.15
   requires_python: '>=3.5'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
+  sha256: 2254dae821b286fb57c61895f2b40e3571a070910fdab79a948ff703e1ea807b
+  md5: 56f8947aa9d5cf37b0b3d43b83f34192
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - opencl-headers >=2024.10.24
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 106742
+  timestamp: 1743700382939
+- conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
+  sha256: 2b6ce54174ec19110e1b3c37455f7cd138d0e228a75727a9bba443427da30a36
+  md5: 45c3d2c224002d6d0d7769142b29f986
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 55357
+  timestamp: 1749853464518
+- conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
+  sha256: 3f231f2747a37a58471c82a9a8a80d92b7fece9f3fce10901a5ac888ce00b747
+  md5: b28cf020fd2dead0ca6d113608683842
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 731471
+  timestamp: 1739400677213
+- conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.6.0-hb17fa0b_0.conda
+  sha256: 914702d9a64325ff3afb072c8bc0f8cbea3f19955a8395a8c190e45604f83c76
+  md5: ad4cac6ceb9e4c8e01802e3f15e87bb2
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 411269
+  timestamp: 1739401120354
 - pypi: https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl
   name: openpyxl
   version: 3.1.5
@@ -4548,6 +6775,49 @@ packages:
   version: 1.5.1
   sha256: 93be382804a9cdb0a7267585f157e5d1731bbe5545a85b268d6f5fe6232de2bc
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
+  sha256: 3613774ad27e48503a3a6a9d72017087ea70f1426f6e5541dbdb59a3b626eaaf
+  md5: 79f71230c069a287efe3a8614069ddf1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cairo >=1.18.4,<2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=11.0.1
+  - libexpat >=2.7.0,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libgcc >=13
+  - libglib >=2.84.2,<3.0a0
+  - libpng >=1.6.49,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 455420
+  timestamp: 1751292466873
+- conda: https://conda.anaconda.org/conda-forge/win-64/pango-1.56.4-h03d888a_0.conda
+  sha256: dcda7e9bedc1c87f51ceef7632a5901e26081a1f74a89799a3e50dbdc801c0bd
+  md5: 452d6d3b409edead3bd90fc6317cd6d4
+  depends:
+  - cairo >=1.18.4,<2.0a0
+  - fontconfig >=2.15.0,<3.0a0
+  - fonts-conda-ecosystem
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=11.0.1
+  - libexpat >=2.7.0,<3.0a0
+  - libfreetype >=2.13.3
+  - libfreetype6 >=2.13.3
+  - libglib >=2.84.2,<3.0a0
+  - libpng >=1.6.49,<1.7.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.1-or-later
+  purls: []
+  size: 454854
+  timestamp: 1751292618315
 - pypi: https://files.pythonhosted.org/packages/11/da/9d476e9aadfa854719f3cb917e3f7a170a657a182d8d1d6e546594a4872b/param-2.3.1-py3-none-any.whl
   name: param
   version: 2.3.1
@@ -4665,6 +6935,33 @@ packages:
   version: 0.12.1
   sha256: a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
+  sha256: 5e6f7d161356fefd981948bea5139c5aa0436767751a6930cb1ca801ebb113ff
+  md5: 7a3bff861a6583f1889021facefc08b1
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc >=14
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 1222481
+  timestamp: 1763655398280
+- conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.47-hd2b5f0e_0.conda
+  sha256: 3e9e02174edf02cb4bcdd75668ad7b74b8061791a3bc8bdb8a52ae336761ba3e
+  md5: 77eaf2336f3ae749e712f63e36b0f0a1
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 995992
+  timestamp: 1763655708300
 - pypi: https://files.pythonhosted.org/packages/55/26/d0ad8b448476d0a1e8d3ea5622dc77b916db84c6aa3cb1e1c0965af948fc/pefile-2023.2.7-py3-none-any.whl
   name: pefile
   version: 2023.2.7
@@ -4802,6 +7099,34 @@ packages:
   - uncertainties>=3.1.6 ; extra == 'uncertainties'
   - xarray ; extra == 'xarray'
   requires_python: '>=3.11'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
+  sha256: 43d37bc9ca3b257c5dd7bf76a8426addbdec381f6786ff441dc90b1a49143b6a
+  md5: c01af13bdc553d1a8fbfff6e8db075f0
+  depends:
+  - libgcc >=14
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 450960
+  timestamp: 1754665235234
+- conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.46.4-h5112557_1.conda
+  sha256: 246fce4706b3f8b247a7d6142ba8d732c95263d3c96e212b9d63d6a4ab4aff35
+  md5: 08c8fa3b419df480d985e304f7884d35
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 542795
+  timestamp: 1754665193489
 - pypi: https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl
   name: platformdirs
   version: 4.5.1
@@ -5033,10 +7358,52 @@ packages:
   - wheel ; os_name == 'nt' and platform_python_implementation != 'PyPy' and extra == 'test'
   - wmi ; os_name == 'nt' and platform_python_implementation != 'PyPy' and extra == 'test'
   requires_python: '>=3.6'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
+  sha256: 9c88f8c64590e9567c6c80823f0328e58d3b1efb0e1c539c0315ceca764e0973
+  md5: b3c17d95b5a10c6e64a21fa17573e70e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 8252
+  timestamp: 1726802366959
 - pypi: https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl
   name: ptyprocess
   version: 0.7.0
   sha256: 4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.15-h3f63f65_0.conda
+  sha256: 23c98a5000356e173568dc5c5770b53393879f946f3ace716bbdefac2a8b23d2
+  md5: b11a4c6bf6f6f44e5e143f759ffa2087
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 118488
+  timestamp: 1736601364156
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-17.0-h9a6aba3_3.conda
+  sha256: 0a0858c59805d627d02bdceee965dd84fde0aceab03a2f984325eec08d822096
+  md5: b8ea447fdf62e3597cb8d2fae4eb1a90
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - dbus >=1.16.2,<2.0a0
+  - libgcc >=14
+  - libglib >=2.86.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - libsndfile >=1.2.2,<1.3.0a0
+  - libsystemd0 >=257.10
+  - libxcb >=1.17.0,<2.0a0
+  constrains:
+  - pulseaudio 17.0 *_3
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  purls: []
+  size: 750785
+  timestamp: 1763148198088
 - pypi: https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl
   name: pure-eval
   version: 0.2.3
@@ -5300,6 +7667,17 @@ packages:
   version: 1.2.0
   sha256: 9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913
   requires_python: '>=3.7'
+- pypi: https://files.pythonhosted.org/packages/82/06/cad54e8ce758bd836ee5411691cbd49efeb9cc611b374670fce299519334/pyshp-3.0.3-py3-none-any.whl
+  name: pyshp
+  version: 3.0.3
+  sha256: 28c8fac8c0c25bb0fecbbfd10ead7f319c2ff2f3b0b44a94f22bd2c93510ad42
+  requires_dist:
+  - pre-commit ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - ruff ; extra == 'dev'
+  - pyshp-stubs ; extra == 'stubs'
+  - pytest ; extra == 'test'
+  requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/c0/01/eb465e19137b36ba683417e982907aa9c7df1fb0b968e1424e5d678ba0dc/pystac-1.14.1-py3-none-any.whl
   name: pystac
   version: 1.14.1
@@ -6097,6 +8475,78 @@ packages:
   - doit>=0.36.0 ; extra == 'dev'
   - pydevtool ; extra == 'dev'
   requires_python: '>=3.11'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl2-2.32.56-h54a6638_0.conda
+  sha256: 987ad072939fdd51c92ea8d3544b286bb240aefda329f9b03a51d9b7e777f9de
+  md5: cdd138897d94dc07d99afe7113a07bec
+  depends:
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libgl >=1.7.0,<2.0a0
+  - sdl3 >=3.2.22,<4.0a0
+  - libegl >=1.7.0,<2.0a0
+  license: Zlib
+  purls: []
+  size: 589145
+  timestamp: 1757842881
+- conda: https://conda.anaconda.org/conda-forge/win-64/sdl2-2.32.56-h5112557_0.conda
+  sha256: d17da21386bdbf32bce5daba5142916feb95eed63ef92b285808c765705bbfd2
+  md5: 4cffbfebb6614a1bff3fc666527c25c7
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - sdl3 >=3.2.22,<4.0a0
+  license: Zlib
+  purls: []
+  size: 572101
+  timestamp: 1757842925694
+- conda: https://conda.anaconda.org/conda-forge/linux-64/sdl3-3.4.0-h3b84278_0.conda
+  sha256: 5ce26a1c92efe8d868c2ab519e6b6144eb825c1f674f6ee8202e26ff0014f87b
+  md5: 8ed4794e19f59dd46ed13b126815404e
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - xorg-libxfixes >=6.0.2,<7.0a0
+  - wayland >=1.24.0,<2.0a0
+  - xorg-libxi >=1.8.2,<2.0a0
+  - xorg-libxext >=1.3.7,<2.0a0
+  - libudev1 >=257.10
+  - xorg-libxtst >=1.2.5,<2.0a0
+  - libvulkan-loader >=1.4.328.1,<2.0a0
+  - libusb >=1.0.29,<2.0a0
+  - xorg-libxscrnsaver >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - libgl >=1.7.0,<2.0a0
+  - liburing >=2.13,<2.14.0a0
+  - dbus >=1.16.2,<2.0a0
+  - libxkbcommon >=1.13.1,<2.0a0
+  - pulseaudio-client >=17.0,<17.1.0a0
+  - libunwind >=1.8.3,<1.9.0a0
+  - libdrm >=2.4.125,<2.5.0a0
+  - xorg-libxcursor >=1.2.3,<2.0a0
+  - libegl >=1.7.0,<2.0a0
+  license: Zlib
+  purls: []
+  size: 2135704
+  timestamp: 1769627942331
+- conda: https://conda.anaconda.org/conda-forge/win-64/sdl3-3.4.0-h5112557_0.conda
+  sha256: a054c1594540e724e3a3b55c380db0c638a87eb9a5c6221d312df8b1709d5fa7
+  md5: 8952a107eab070e74eb4dbc476e2cb5b
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libvulkan-loader >=1.4.328.1,<2.0a0
+  - libusb >=1.0.29,<2.0a0
+  license: Zlib
+  purls: []
+  size: 1666227
+  timestamp: 1769627996115
 - pypi: https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl
   name: secretstorage
   version: 3.5.0
@@ -6172,6 +8622,34 @@ packages:
   - importlib-metadata>=7.0.2 ; python_full_version < '3.10' and extra == 'type'
   - jaraco-develop>=7.21 ; sys_platform != 'cygwin' and extra == 'type'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/shaderc-2025.5-h718be3e_1.conda
+  sha256: 0c2d6f24ee2b614ee1da4d7d99cc9944ea1ace65455a47d48d8c1f726317168a
+  md5: 8dc8dda113c4c568256bdd486b6e842e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - glslang >=16,<17.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - spirv-tools >=2026,<2027.0a0
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 113513
+  timestamp: 1770208767759
+- conda: https://conda.anaconda.org/conda-forge/win-64/shaderc-2025.5-h8fa7867_1.conda
+  sha256: b2f6e199df47ca314294ad393818d6b499fd544703abcede0f19007b8f8f10e4
+  md5: 04d62bc008ee442843e2f24f603ea1a6
+  depends:
+  - glslang >=16,<17.0a0
+  - spirv-tools >=2026,<2027.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: Apache-2.0
+  license_family: Apache
+  purls: []
+  size: 1558909
+  timestamp: 1770208850155
 - pypi: https://files.pythonhosted.org/packages/b9/37/e781683abac55dde9771e086b790e554811a71ed0b2b8a1e789b7430dd44/shapely-2.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
   name: shapely
   version: 2.1.2
@@ -6232,6 +8710,19 @@ packages:
   version: 1.17.0
   sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
   requires_python: '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
+  sha256: 48f3f6a76c34b2cfe80de9ce7f2283ecb55d5ed47367ba91e8bb8104e12b8f11
+  md5: 98b6c9dc80eb87b2519b97bcf7e578dd
+  depends:
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 45829
+  timestamp: 1762948049098
 - pypi: https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl
   name: snowballstemmer
   version: 3.0.1
@@ -6381,6 +8872,34 @@ packages:
   - certifi
   - jsonschema>=3.0
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/spirv-tools-2026.1-hb700be7_0.conda
+  sha256: 003180b3a2e0c6490b1f3461cf9e0ed740b1bbf88ee4b73ee177b94bea0dc95d
+  md5: 8809e0bd5ec279bfe4bb6651c3ed2730
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  constrains:
+  - spirv-headers >=1.4.341.0,<1.4.341.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 2296977
+  timestamp: 1770089626195
+- conda: https://conda.anaconda.org/conda-forge/win-64/spirv-tools-2026.1-h49e36cd_0.conda
+  sha256: 9976eeaf650d43833c110447ba264a72f470928d8a8fa5d1cfbadcd2a276184c
+  md5: bf5a4eb05c8b38dbc4e32ce17ab36389
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  constrains:
+  - spirv-headers >=1.4.341.0,<1.4.341.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 13881533
+  timestamp: 1770089875437
 - pypi: https://files.pythonhosted.org/packages/0a/93/3be94d96bb442d0d9a60e55a6bb6e0958dd3457751c6f8502e56ef95fed0/sqlalchemy-2.0.45-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: sqlalchemy
   version: 2.0.45
@@ -6470,6 +8989,30 @@ packages:
   - pygments ; extra == 'tests'
   - littleutils ; extra == 'tests'
   - cython ; extra == 'tests'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-4.0.1-hecca717_0.conda
+  sha256: 4a1d2005153b9454fc21c9bad1b539df189905be49e851ec62a6212c2e045381
+  md5: 2a2170a3e5c9a354d09e4be718c43235
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 2619743
+  timestamp: 1769664536467
+- conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-4.0.1-hac47afa_0.conda
+  sha256: 4d77eec06ee4c5de38d330fb7dfd6dac2f867ec007123acb901be9942e12c08a
+  md5: d9714a97bc69f98fd5032f675ae1b0b5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  license: BSD-2-Clause
+  license_family: BSD
+  purls: []
+  size: 1808810
+  timestamp: 1769664619287
 - pypi: https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl
   name: tabulate
   version: 0.9.0
@@ -6477,6 +9020,19 @@ packages:
   requires_dist:
   - wcwidth ; extra == 'widechars'
   requires_python: '>=3.7'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2022.3.0-hb700be7_2.conda
+  sha256: 975710e4b7f1b13c3c30b7fbf21e22f50abe0463b6b47a231582fdedcc45c961
+  md5: 8f7278ca5f7456a974992a8b34284737
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libhwloc >=2.12.2,<2.12.3.0a0
+  - libstdcxx >=14
+  license: Apache-2.0
+  license_family: APACHE
+  purls: []
+  size: 181329
+  timestamp: 1767886632911
 - pypi: https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl
   name: terminado
   version: 0.18.1
@@ -6833,6 +9389,16 @@ packages:
   - setuptools>=68 ; extra == 'test'
   - time-machine>=2.10 ; platform_python_implementation == 'CPython' and extra == 'test'
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.44.35208-h38c0c73_33.conda
+  sha256: 93fc61d05770f4c6b66214ed3494f632bf6e0e6ee7fcb0fb0a847a4bed131953
+  md5: 65e5a2127012cd4dbc9354579661b9fd
+  depends:
+  - vc14_runtime >=14.44.35208
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 19159
+  timestamp: 1765216369037
 - pypi: https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl
   name: watchdog
   version: 6.0.0
@@ -6847,6 +9413,28 @@ packages:
   requires_dist:
   - pyyaml>=3.10 ; extra == 'watchmedo'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.24.0-hd6090a7_1.conda
+  sha256: 3aa04ae8e9521d9b56b562376d944c3e52b69f9d2a0667f77b8953464822e125
+  md5: 035da2e4f5770f036ff704fa17aace24
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libexpat >=2.7.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - libstdcxx >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 329779
+  timestamp: 1761174273487
+- conda: https://conda.anaconda.org/conda-forge/noarch/wayland-protocols-1.47-hd8ed1ab_0.conda
+  sha256: 9ab2c12053ea8984228dd573114ffc6d63df42c501d59fda3bf3aeb1eaa1d23e
+  md5: 7da1571f560d4ba3343f7f4c48a79c76
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 140476
+  timestamp: 1765821981856
 - pypi: https://files.pythonhosted.org/packages/af/b5/123f13c975e9f27ab9c0770f514345bd406d0e8d3b7a0723af9d43f710af/wcwidth-0.2.14-py2.py3-none-any.whl
   name: wcwidth
   version: 0.2.14
@@ -6887,6 +9475,49 @@ packages:
   version: 4.0.15
   sha256: 8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366
   requires_python: '>=3.7'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+  sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
+  md5: 6c99772d483f566d59e25037fea2c4b1
+  depends:
+  - libgcc-ng >=12
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 897548
+  timestamp: 1660323080555
+- conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
+  sha256: 97166b318f8c68ffe4d50b2f4bd36e415219eeaef233e7d41c54244dc6108249
+  md5: 19e39905184459760ccb8cf5c75f148b
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 1041889
+  timestamp: 1660323726084
+- conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+  sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
+  md5: e7f6ed84d4623d52ee581325c1587a6b
+  depends:
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 3357188
+  timestamp: 1646609687141
+- conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
+  sha256: 02b9874049112f2b7335c9a3e880ac05d99a08d9a98160c5a98898b2b3ac42b2
+  md5: ca7129a334198f08347fb19ac98a2de9
+  depends:
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
+  license: GPL-2.0-or-later
+  license_family: GPL
+  purls: []
+  size: 5517425
+  timestamp: 1646611941216
 - pypi: https://files.pythonhosted.org/packages/d5/e4/62a677feefde05b12a70a4fc9bdc8558010182a801fbcab68cb56c2b0986/xarray-2025.12.0-py3-none-any.whl
   name: xarray
   version: 2025.12.0
@@ -6966,6 +9597,18 @@ packages:
   - pytest ; extra == 'tests'
   - pytest-cov ; extra == 'tests'
   requires_python: '>=3.8'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.46-hb03c661_0.conda
+  sha256: aa03b49f402959751ccc6e21932d69db96a65a67343765672f7862332aa32834
+  md5: 71ae752a748962161b4740eaff510258
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 396975
+  timestamp: 1759543819846
 - pypi: https://files.pythonhosted.org/packages/c0/20/69a0e6058bc5ea74892d089d64dfc3a62ba78917ec5e2cfa70f7c92ba3a5/xmltodict-1.0.2-py3-none-any.whl
   name: xmltodict
   version: 1.0.2
@@ -6974,6 +9617,169 @@ packages:
   - pytest ; extra == 'test'
   - pytest-cov ; extra == 'test'
   requires_python: '>=3.9'
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
+  sha256: c12396aabb21244c212e488bbdc4abcdef0b7404b15761d9329f5a4a39113c4b
+  md5: fb901ff28063514abb6046c9ec2c4a45
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 58628
+  timestamp: 1734227592886
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
+  sha256: 277841c43a39f738927145930ff963c5ce4c4dacf66637a3d95d802a64173250
+  md5: 1c74ff8c35dcadf952a16f752ca5aa49
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.2,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 27590
+  timestamp: 1741896361728
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_0.conda
+  sha256: 516d4060139dbb4de49a4dcdc6317a9353fb39ebd47789c14e6fe52de0deee42
+  md5: 861fb6ccbc677bb9a9fb2468430b9c6a
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libxcb >=1.17.0,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 839652
+  timestamp: 1770819209719
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_1.conda
+  sha256: 6bc6ab7a90a5d8ac94c7e300cc10beb0500eeba4b99822768ca2f2ef356f731b
+  md5: b2895afaf55bf96a8c8282a2e47a5de0
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 15321
+  timestamp: 1762976464266
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxcursor-1.2.3-hb9d3cd8_0.conda
+  sha256: 832f538ade441b1eee863c8c91af9e69b356cd3e9e1350fff4fe36cc573fc91a
+  md5: 2ccd714aa2242315acaf0a67faea780b
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 32533
+  timestamp: 1730908305254
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_1.conda
+  sha256: 25d255fb2eef929d21ff660a0c687d38a6d2ccfbcbf0cc6aa738b12af6e9d142
+  md5: 1dafce8548e38671bea82e3f5c6ce22f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 20591
+  timestamp: 1762976546182
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-hb03c661_0.conda
+  sha256: 79c60fc6acfd3d713d6340d3b4e296836a0f8c51602327b32794625826bd052f
+  md5: 34e54f03dfea3e7a2dcf1453a85f1085
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 50326
+  timestamp: 1769445253162
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-hb03c661_0.conda
+  sha256: 83c4c99d60b8784a611351220452a0a85b080668188dce5dfa394b723d7b64f4
+  md5: ba231da7fccf9ea1e768caf5c7099b84
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 20071
+  timestamp: 1759282564045
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.2-hb9d3cd8_0.conda
+  sha256: 1a724b47d98d7880f26da40e45f01728e7638e6ec69f35a3e11f92acd05f9e7a
+  md5: 17dcc85db3c7886650b8908b183d6876
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxfixes >=6.0.1,<7.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 47179
+  timestamp: 1727799254088
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-hb03c661_0.conda
+  sha256: 80ed047a5cb30632c3dc5804c7716131d767089f65877813d4ae855ee5c9d343
+  md5: e192019153591938acf7322b6459d36e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - xorg-libx11 >=1.8.12,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxrender >=0.9.12,<0.10.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 30456
+  timestamp: 1769445263457
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb9d3cd8_0.conda
+  sha256: 044c7b3153c224c6cedd4484dd91b389d2d7fd9c776ad0f4a34f099b3389f4a1
+  md5: 96d57aba173e878a2089d5638016dc5e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 33005
+  timestamp: 1734229037766
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxscrnsaver-1.2.4-hb9d3cd8_0.conda
+  sha256: 58e8fc1687534124832d22e102f098b5401173212ac69eb9fd96b16a3e2c8cb2
+  md5: 303f7a0e9e0cd7d250bb6b952cecda90
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 14412
+  timestamp: 1727899730073
+- conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-hb9d3cd8_3.conda
+  sha256: 752fdaac5d58ed863bbf685bb6f98092fe1a488ea8ebb7ed7b606ccfce08637a
+  md5: 7bbe9a0cc0df0ac5f5a8ad6d6a11af2f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - xorg-libx11 >=1.8.10,<2.0a0
+  - xorg-libxext >=1.3.6,<2.0a0
+  - xorg-libxi >=1.7.10,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 32808
+  timestamp: 1727964811275
 - pypi: https://files.pythonhosted.org/packages/52/07/1922a0c20ed4c95769937619d2c0217ee3f665a8b967438277d3f40860e4/xugrid-0.14.3-py3-none-any.whl
   name: xugrid
   version: 0.14.3
@@ -7120,3 +9926,16 @@ packages:
   purls: []
   size: 601375
   timestamp: 1764777111296
+- conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
+  sha256: 368d8628424966fd8f9c8018326a9c779e06913dd39e646cf331226acc90e5b2
+  md5: 053b84beec00b71ea8ff7a4f84b55207
+  depends:
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libzlib >=1.3.1,<2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  purls: []
+  size: 388453
+  timestamp: 1764777142545

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ flood_adapt = ["py.typed", "database_builder/**"]
 ### pytest ###
 [tool.pytest.ini_options]
 addopts = "--junitxml report.xml --cov flood_adapt --cov-report html --cov-fail-under 70"
+markers = [
+    "integration: runs external binaries (SFINCS/FIAT)",
+]
 testpaths = ["tests"]
 
 ### pixi ###
@@ -129,7 +132,9 @@ update-test-db = { depends-on = ["update-test-db-static", "update-test-db-input"
 install-pre-commit = {cmd = "pre-commit install", outputs=[".git/hooks/pre-commit"] }
 pre-commit = {cmd = "pre-commit run --all-files", depends-on=["install-pre-commit"] }
 lint = { depends-on=["pre-commit"] }
-tests = {cmd = "pytest tests"}
+tests-unit = { cmd = "pytest tests -m 'not integration'" }
+tests-integration = { cmd = "pytest tests -m integration" }
+tests = { cmd = "pytest tests" }
 
 [tool.pixi.feature.build.tasks]
 build-db-builder = {cmd = "python distribution/build_database_builder_executable.py" }

--- a/tests/data/create_test_input.py
+++ b/tests/data/create_test_input.py
@@ -899,5 +899,6 @@ if __name__ == "__main__":
         DATABASE_ROOT=args.database_root,
         DATABASE_NAME=args.database_name,
     )
+    settings.export_to_env()
     print(f"Updating database: {settings.database_path}")
     update_database_input(settings.database_path)

--- a/tests/data/create_test_input.py
+++ b/tests/data/create_test_input.py
@@ -86,12 +86,9 @@ def update_database_input(database_path: Path):
         The path to the database directory. This is the directory that contains the `input`, `static` and `output` directories.
 
     """
-    database = Database(database_path.parent, database_path.name)
-    input_dir = database.input_path
-    if input_dir.exists():
-        shutil.rmtree(input_dir)
-
-    input_dir.mkdir(parents=True)
+    # Clear existing input and output directories
+    shutil.rmtree(database_path / "input", ignore_errors=True)
+    shutil.rmtree(database_path / "output", ignore_errors=True)
     for obj_dir in [
         "events",
         "projections",
@@ -100,27 +97,33 @@ def update_database_input(database_path: Path):
         "scenarios",
         "benefits",
     ]:
-        (input_dir / obj_dir).mkdir()
+        (database_path / "input" / obj_dir).mkdir(parents=True, exist_ok=True)
+
+    # Initialize database
+    database = Database(database_path.parent, database_path.name)
 
     for event in create_events():
-        database.events.save(event)
+        database.events.add(event)
 
     for projection in create_projections():
-        database.projections.save(projection)
+        database.projections.add(projection)
 
     for measure in create_measures():
-        database.measures.save(measure)
+        database.measures.add(measure)
 
     for strategy in create_strategies():
-        database.strategies.save(strategy)
+        database.strategies.add(strategy)
 
     for scenario in create_scenarios():
-        database.scenarios.save(scenario)
+        database.scenarios.add(scenario)
 
     for benefit in create_benefits():
         runner = BenefitRunner(database, benefit)
         runner.create_benefit_scenarios()
-        database.benefits.save(benefit)
+        database.benefits.add(benefit)
+
+    # write to disk
+    database.flush()
 
     # Cleanup singleton
     database.shutdown()

--- a/tests/data/create_test_static.py
+++ b/tests/data/create_test_static.py
@@ -392,5 +392,6 @@ if __name__ == "__main__":
         DATABASE_ROOT=Path(args.database_root).resolve(),
         DATABASE_NAME=args.database_name,
     )
+    settings.export_to_env()
     print(f"Updating database: {settings.database_path}")
     update_database_static(settings.database_path)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -90,7 +90,7 @@ def dummy_strategy(test_db, dummy_buyout_measure, dummy_pump_measure):
     )
 
     for measure in [buyout, pump]:
-        test_db.measures.save(measure)
+        test_db.measures.add(measure)
 
     return model
 

--- a/tests/test_adapter/test_fiat_adapter.py
+++ b/tests/test_adapter/test_fiat_adapter.py
@@ -13,6 +13,9 @@ from tests.conftest import IS_WINDOWS
 
 _FIAT_COLUMNS = get_fiat_columns()
 
+# mark all tests in this module as integration tests
+pytestmark = pytest.mark.integration
+
 
 @pytest.mark.skipif(
     not IS_WINDOWS,

--- a/tests/test_adapter/test_offshore.py
+++ b/tests/test_adapter/test_offshore.py
@@ -58,7 +58,7 @@ def setup_offshore_scenario(test_db: IDatabase):
             ],
         },
     )
-    test_db.events.save(event)
+    test_db.events.add(event)
 
     scn = Scenario(
         name="test_scenario",
@@ -66,7 +66,7 @@ def setup_offshore_scenario(test_db: IDatabase):
         projection="current",
         strategy="no_measures",
     )
-    test_db.scenarios.save(scn)
+    test_db.scenarios.add(scn)
 
     return test_db, scn, event
 

--- a/tests/test_adapter/test_sfincs_adapter.py
+++ b/tests/test_adapter/test_sfincs_adapter.py
@@ -1000,7 +1000,7 @@ class TestAddMeasure:
                 polygon_file=str(TEST_DATA_DIR / "seawall.geojson"),
             )
 
-            test_db.measures.save(floodwall)
+            test_db.measures.add(floodwall)
             return floodwall
 
         def test_add_measure_floodwall(
@@ -1093,7 +1093,7 @@ class TestAddMeasure:
                 selection_type=SelectionType.polyline,
                 polygon_file=str(TEST_DATA_DIR / "pump.geojson"),
             )
-            test_db.measures.save(pump)
+            test_db.measures.add(pump)
             return pump
 
         def test_add_measure_pump(
@@ -1203,7 +1203,7 @@ class TestAddMeasure:
                 percent_area=0.5,
             )
 
-            test_db.measures.save(green_infra)
+            test_db.measures.add(green_infra)
             return green_infra
 
         def test_add_measure_greeninfra(
@@ -1480,14 +1480,14 @@ class TestPostProcessing:
             end_time=start_time + duration,
         )
         event.time = time
-        test_db_class.events.save(event)
+        test_db_class.events.add(event)
         scn = Scenario(
             name="synthetic",
             event=event.name,
             projection="current",
             strategy="no_measures",
         )
-        test_db_class.scenarios.save(scn)
+        test_db_class.scenarios.add(scn)
 
         # Prepare adapter
         overland_path = (
@@ -1530,6 +1530,7 @@ class TestPostProcessing:
         return_periods = [2, 50, 100]
         return floodmaps, frequencies, zb, mask, return_periods
 
+    @pytest.mark.integration
     def test_write_geotiff(
         self,
         adapter_preprocess_process_scenario_class: Tuple[SfincsAdapter, Scenario],

--- a/tests/test_dbs_classes/test_dbs_template.py
+++ b/tests/test_dbs_classes/test_dbs_template.py
@@ -1,0 +1,235 @@
+from pathlib import Path
+
+import pytest
+import tomli_w
+import tomllib
+
+from flood_adapt.dbs_classes import DbsTemplate
+from flood_adapt.misc.exceptions import (
+    AlreadyExistsError,
+    DoesNotExistError,
+    IsStandardObjectError,
+)
+
+
+class FakeObject:
+    def __init__(self, name, description="desc"):
+        self.name = name
+        self.description = description
+
+    def save(self, path: Path):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "wb") as f:
+            tomli_w.dump({"name": self.name, "description": self.description}, f)
+
+    @classmethod
+    def load_file(cls, path: Path):
+        with open(path, "rb") as f:
+            data = tomllib.load(f)
+        return cls(**data)
+
+    def model_copy(self, deep=True):
+        return FakeObject(self.name, self.description)
+
+    def model_validate(self, _):
+        pass
+
+
+class FakeRepo(DbsTemplate[FakeObject]):
+    dir_name = "objects"
+    display_name = "Object"
+    _object_class = FakeObject
+    _higher_lvl_object = "Parent"
+
+
+class FakeDB:
+    def __init__(self, base):
+        self.input_path = base / "input"
+        self.output_path = base / "output"
+
+
+def test_load(tmp_path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db)
+
+    obj = FakeObject("a")
+    obj.save(tmp_path / "input/objects/a/a.toml")
+
+    repo.load()
+
+    assert repo.get("a").name == "a"
+    assert repo._mutated == set(), "loading must not stage mutations"
+
+
+def test_add_and_flush(tmp_path: Path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db)
+    obj = FakeObject("b")
+    expected_path = repo.input_path / obj.name / f"{obj.name}.toml"
+
+    repo.add(obj)
+    assert not expected_path.exists()
+    assert obj.name in repo._mutated
+    print(repo._mutated)
+
+    repo.flush()
+    assert expected_path.exists()
+    assert repo._mutated == set()
+
+
+def test_delete_and_flush(tmp_path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db)
+    obj = FakeObject("c")
+    expected_path = repo.input_path / obj.name / f"{obj.name}.toml"
+
+    repo.add(obj)
+    repo.flush()
+    assert expected_path.exists()
+
+    repo.delete("c")
+    assert expected_path.exists()
+    assert obj.name in repo._deleted
+
+    repo.flush()
+    assert not expected_path.parent.exists()
+    assert repo._mutated == set()
+
+
+def test_copy_is_deep(tmp_path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db)
+
+    repo.add(FakeObject("orig", "hello"))
+    repo.copy("orig", "clone", "new")
+
+    clone = repo.get("clone")
+    clone.description = "changed"
+
+    # original must remain untouched
+    assert repo.get("orig").description == "hello"
+
+
+def test_add_duplicate_without_overwrite_raises(tmp_path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db)
+    obj = FakeObject("x")
+    repo.add(obj)
+
+    with pytest.raises(AlreadyExistsError):
+        repo.add(obj, overwrite=False)
+
+
+def test_add_duplicate_with_overwrite(tmp_path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db)
+    obj = FakeObject("x")
+    repo.add(obj)
+    repo.add(obj, overwrite=True)
+    assert obj.name in repo._mutated
+
+
+def test_standard_object_protected(tmp_path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db, standard_objects=["std"])
+
+    repo._objects["std"] = FakeObject("std")
+
+    with pytest.raises(IsStandardObjectError):
+        repo.delete("std")
+
+
+def test_get_returns_copy(tmp_path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db)
+    obj = FakeObject("safe")
+
+    repo.add(obj)
+
+    copied = repo.get("safe")
+    copied.description = "mutated"
+
+    assert repo.get("safe").description == obj.description
+
+
+def test_flush_is_idempotent(tmp_path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db)
+
+    repo.add(FakeObject("a"))
+    repo.flush()
+
+    # second flush should do nothing, and not error
+    repo.flush()
+
+    assert repo._mutated == set()
+    assert repo._deleted == set()
+
+
+def test_add_then_delete_before_flush(tmp_path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db)
+
+    repo.add(FakeObject("temp"))
+    repo.delete("temp")
+
+    repo.flush()
+
+    assert not (repo.input_path / "temp").exists()
+
+
+def test_overwrite_replaces_disk_content(tmp_path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db)
+
+    repo.add(FakeObject("x", "old"))
+    repo.flush()
+
+    repo.add(FakeObject("x", "new"), overwrite=True)
+    repo.flush()
+
+    loaded = FakeObject.load_file(repo.input_path / "x/x.toml")
+
+    assert loaded.description == "new"
+
+
+def test_load_twice_is_safe(tmp_path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db)
+
+    FakeObject("a").save(tmp_path / "input/objects/a/a.toml")
+
+    repo.load()
+    repo.load()
+
+    assert len(repo.list_all()) == 1
+    assert repo._mutated == set()
+
+
+def test_get_missing_raises(tmp_path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db)
+
+    with pytest.raises(DoesNotExistError):
+        repo.get("not_exists")
+
+
+def test_delete_missing_raises(tmp_path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db)
+
+    with pytest.raises(DoesNotExistError):
+        repo.delete("not_exists")
+
+
+def test_mutating_returned_object_does_not_stage_mutation(tmp_path):
+    db = FakeDB(tmp_path)
+    repo = FakeRepo(db)
+
+    repo.add(FakeObject("safe"))
+    repo.flush()
+
+    obj = repo.get("safe")
+    obj.description = "changed"
+
+    assert "safe" not in repo._mutated

--- a/tests/test_flood_adapt.py
+++ b/tests/test_flood_adapt.py
@@ -6,13 +6,9 @@ import pytest
 from flood_adapt.flood_adapt import FloodAdapt
 from flood_adapt.misc.exceptions import (
     AlreadyExistsError,
-    DatabaseError,
-    DoesNotExistError,
-    IsUsedInError,
 )
 from flood_adapt.misc.utils import finished_file_exists
 from flood_adapt.objects.events.hurricane import HurricaneEvent
-from flood_adapt.objects.measures.measures import Measure
 from flood_adapt.objects.scenarios.scenarios import Scenario
 from flood_adapt.workflows.benefit_runner import BenefitRunner
 from tests.conftest import IS_WINDOWS
@@ -24,8 +20,6 @@ from tests.test_objects.test_events.test_eventset import (
 )
 from tests.test_objects.test_events.test_historical import (
     setup_nearshore_event,
-    setup_offshore_meteo_event,
-    setup_offshore_scenario,
 )
 from tests.test_objects.test_events.test_hurricane import setup_hurricane_event
 from tests.test_objects.test_events.test_synthetic import test_event_all_synthetic
@@ -46,10 +40,7 @@ __all__ = [
     "test_event_all_synthetic",
     "create_event_set_with_hurricanes",
     "setup_nearshore_event",
-    "setup_offshore_meteo_event",
     "setup_hurricane_event",
-    # Scenarios
-    "setup_offshore_scenario",
     # Mock
     "mock_meteohandler_read",
     # Measures
@@ -67,222 +58,11 @@ def get_rng():
     yield np.random.default_rng(2021)
 
 
-class TestEvents:
-    @pytest.fixture()
-    def test_dict(self):
-        test_dict = {
-            "name": "extreme12ft",
-            "description": "extreme 12 foot event",
-            "mode": "single_event",
-            "template": "Synthetic",
-            "timing": "idealized",
-            "water_level_offset": {"value": 0, "units": "feet"},
-            "wind": {
-                "source": "constant",
-                "constant_speed": {"value": 0, "units": "m/s"},
-                "constant_direction": {"value": 0, "units": "deg N"},
-            },
-            "rainfall": {"source": "none"},
-            "river": [
-                {
-                    "source": "constant",
-                    "constant_discharge": {"value": 5000, "units": "cfs"},
-                }
-            ],
-            "time": {"duration_before_t0": 24, "duration_after_t0": "24"},
-            "tide": {
-                "source": "harmonic",
-                "harmonic_amplitude": {"value": 3, "units": "feet"},
-            },
-            "surge": {
-                "source": "shape",
-                "shape_type": "gaussian",
-                "shape_duration": 24,
-                "shape_peak_time": 0,
-                "shape_peak": {"value": 9.22, "units": "feet"},
-            },
-        }
-        yield test_dict
-
-    def test_create_synthetic_event_valid_dict(self, test_fa: FloodAdapt, test_dict):
-        # When user presses add event and chooses the events
-        # the dictionary is returned and an Event object is created
-        test_fa.create_event(test_dict)
-        # TODO assert event attrs
-
-    def test_create_synthetic_event_invalid_dict(self, test_fa: FloodAdapt, test_dict):
-        del test_dict["name"]
-        with pytest.raises(ValueError):
-            # Assert error if a value is incorrect
-            test_fa.create_event(test_dict)
-        # TODO assert error msg
-
-    def test_save_synthetic_event_already_exists(self, test_fa: FloodAdapt, test_dict):
-        event = test_fa.create_event(test_dict)
-        if test_dict["name"] not in test_fa.get_events()["name"]:
-            test_fa.save_event(event)
-
-        with pytest.raises(AlreadyExistsError):
-            test_fa.save_event(event)
-
-    def test_save_event_valid(self, test_fa: FloodAdapt, test_dict):
-        # Change name to something new
-        name = "testNew"
-        test_dict["name"] = name
-        event = test_fa.create_event(test_dict)
-        if test_dict["name"] in test_fa.get_events()["name"]:
-            test_fa.delete_event(test_dict["name"])
-
-        test_fa.save_event(event)
-
-        _event = test_fa.get_event(name)
-        assert _event is not None
-        assert _event.name == name
-
-    def test_delete_event_doesnt_exist(self, test_fa: FloodAdapt):
-        with pytest.raises(DoesNotExistError):
-            test_fa.delete_event("doesnt_exist")
-
-
-class TestProjections:
-    def test_projection(self, test_fa: FloodAdapt):
-        test_dict = {
-            "name": "SLR_2ft",
-            "description": "SLR_2ft",
-            "physical_projection": {
-                "sea_level_rise": {"value": "two", "units": "feet"},
-                "subsidence": {"value": 1, "units": "feet"},
-            },
-            "socio_economic_change": {},
-        }
-        # When user presses add projection and chooses the projections
-        # the dictionary is returned and an Projection object is created
-        with pytest.raises(ValueError):
-            # Assert error if a value is incorrect
-            projection = test_fa.create_projection(test_dict)
-
-        # correct projection
-        test_dict["physical_projection"]["sea_level_rise"]["value"] = 2
-        projection = test_fa.create_projection(test_dict)
-
-        with pytest.raises(AlreadyExistsError):
-            test_fa.save_projection(projection)
-
-        # Change name to something new
-        test_dict["name"] = "test_proj_1"
-        projection = test_fa.create_projection(test_dict)
-
-        # If the name is not used before the measure is save in the database
-        test_fa.save_projection(projection)
-        saved = test_fa.get_projection(projection.name)
-        assert saved == projection
-
-        # If user presses delete projection the measure is deleted
-        test_fa.delete_projection(projection.name)
-
-
-class TestMeasures:
-    # dict of measure fixture names and their corresponding measure type
-    measure_fixtures = {
-        "test_elevate": "elevate_properties",
-        "test_buyout": "buyout_properties",
-        "test_floodproof": "floodproof_properties",
-        "test_floodwall": "floodwall",
-        "test_pump": "pump",
-        "test_green_infra": "greening",
-    }
-
-    @pytest.mark.parametrize("measure_fixture_name", measure_fixtures.keys())
-    def test_create_measure(
-        self, test_fa_class: FloodAdapt, measure_fixture_name, request
-    ):
-        measure: Measure = request.getfixturevalue(measure_fixture_name)
-        measure = test_fa_class.create_measure(
-            attrs=measure.model_dump(exclude_none=True), type=measure.type
-        )
-        assert measure is not None
-
-    @pytest.mark.parametrize("measure_fixture", measure_fixtures.keys())
-    def test_save_measure(self, test_fa: FloodAdapt, measure_fixture, request):
-        measure = request.getfixturevalue(measure_fixture)
-
-        test_fa.save_measure(measure)
-        assert (test_fa.database.measures.input_path / measure.name).exists()
-
-    @pytest.mark.parametrize("measure_fixture", measure_fixtures.keys())
-    def test_get_measure(self, test_fa: FloodAdapt, measure_fixture, request):
-        measure = request.getfixturevalue(measure_fixture)
-
-        test_fa.save_measure(measure)
-        assert (test_fa.database.measures.input_path / measure.name).exists()
-
-        loaded_measure = test_fa.get_measure(measure.name)
-        assert loaded_measure == measure
-
-    @pytest.mark.parametrize("measure_fixture", measure_fixtures.keys())
-    def test_delete_measure(self, test_fa: FloodAdapt, measure_fixture, request):
-        measure = request.getfixturevalue(measure_fixture)
-        test_fa.save_measure(measure)
-        assert (test_fa.database.measures.input_path / measure.name).exists()
-
-        test_fa.delete_measure(measure.name)
-        assert not (test_fa.database.measures.input_path / measure.name).exists()
-
-    @pytest.mark.parametrize("measure_fixture", measure_fixtures.keys())
-    def test_copy_measure(self, test_fa: FloodAdapt, measure_fixture, request):
-        measure = request.getfixturevalue(measure_fixture)
-        test_fa.save_measure(measure)
-        assert (test_fa.database.measures.input_path / measure.name).exists()
-
-        new_name = f"copy_{measure.name}"
-        new_description = f"copy of {measure.description}"
-
-        test_fa.copy_measure(
-            old_name=measure.name, new_name=new_name, new_description=new_description
-        )
-        new_measure = test_fa.get_measure(new_name)
-
-        assert (test_fa.database.measures.input_path / new_name).exists()
-        assert measure == new_measure
-
-
-class TestStrategies:
-    def test_strategy(self, test_fa: FloodAdapt):
-        strat_with_existing_name = {
-            "name": "strategy_comb",
-            "description": "strategy_comb",
-            "measures": [
-                "seawall",
-                "raise_property_aggregation_area",
-                "raise_property_polygon",
-            ],
-        }
-        # Create a new strategy object with a name that already exists
-        strategy = test_fa.create_strategy(strat_with_existing_name)
-
-        # Save it in the database -> name exists error
-        with pytest.raises(AlreadyExistsError):
-            test_fa.save_strategy(strategy)
-
-        # Delete a strategy which is already used in a scenario
-        with pytest.raises(IsUsedInError):
-            test_fa.delete_strategy("strategy_comb")
-
-        # Change to unused name
-        strategy.name = "test_strat_1"
-
-        test_fa.save_strategy(strategy)
-        assert test_fa.get_strategy(strategy.name) == strategy
-
-        test_fa.delete_strategy(strategy.name)
-        with pytest.raises(DoesNotExistError):
-            test_fa.get_strategy(strategy.name)
-
-
 @pytest.mark.skipif(
     not IS_WINDOWS,
     reason="Only run on windows where we have a working sfincs binary",
 )
+@pytest.mark.integration
 class TestScenarios:
     @pytest.fixture()
     def setup_nearshore_scenario(self, test_fa: FloodAdapt, setup_nearshore_event):
@@ -295,24 +75,6 @@ class TestScenarios:
             projection="current",
             strategy="no_measures",
         )
-        return scn
-
-    @pytest.fixture()
-    def setup_offshore_meteo_scenario(
-        self,
-        test_fa: FloodAdapt,
-        setup_offshore_meteo_event,
-        mock_meteohandler_read,
-    ):
-        test_fa.save_event(setup_offshore_meteo_event)
-
-        scn = Scenario(
-            name="offshore_meteo",
-            event=setup_offshore_meteo_event.name,
-            projection="current",
-            strategy="no_measures",
-        )
-
         return scn
 
     @pytest.fixture()
@@ -410,49 +172,12 @@ class TestScenarios:
 
         assert finished_file_exists(test_fa.database.scenarios.output_path / scn.name)
 
-    @pytest.mark.skip(
-        reason="Skipped until METEO forcing is fixed in hydromt-sfincs 1.3.0",
-    )
-    def test_create_save_scenario(
-        self, test_fa: FloodAdapt, setup_offshore_meteo_event
-    ):
-        test_fa.save_event(setup_offshore_meteo_event)
-
-        test_dict = {
-            "name": "current_extreme12ft_no_measures",
-            "description": "current_extreme12ft_no_measures",
-            "projection": "current",
-            "strategy": "no_measures",
-        }
-        # When user presses add scenario and chooses the measures
-        # the dictionary is returned and a Strategy object is created
-        with pytest.raises(ValueError):
-            # Assert error if the event is not a correct value
-            scenario = test_fa.create_scenario(test_dict)
-
-        # correct event
-        test_dict["event"] = setup_offshore_meteo_event.name
-        scenario = test_fa.create_scenario(test_dict)
-
-        with pytest.raises(DatabaseError):
-            # Assert error if name already exists
-            test_fa.save_scenario(scenario)
-
-        # Change name to something new
-        test_dict["name"] = "test1"
-        scenario = test_fa.create_scenario(test_dict)
-        test_fa.save_scenario(scenario)
-        test_fa.database.scenarios.summarize_objects()
-
-        # If user presses delete scenario the measure is deleted
-        test_fa.delete_scenario("test1")
-        test_fa.database.scenarios.summarize_objects()
-
 
 @pytest.mark.skipif(
     not IS_WINDOWS,
     reason="Only run on windows where we have a working sfincs binary",
 )
+@pytest.mark.integration
 class TestOutput:
     @pytest.fixture(scope="class")
     def completed_scenario(self, test_fa_class: FloodAdapt):

--- a/tests/test_objects/__init__.py
+++ b/tests/test_objects/__init__.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+from typing import TypeVar
+
+from flood_adapt.objects.object_model import Object
+
+T = TypeVar("T", bound=Object)
+
+
+def assert_object_save_load_eq(
+    write_path: Path, obj: T, cls: type[T], load_kwargs: dict | None = None
+):
+    test_path = write_path / "to_load.toml"
+    test_path.parent.mkdir(exist_ok=True)
+
+    obj.save(test_path)
+    loaded = cls.load_file(test_path, **(load_kwargs or {}))
+
+    assert loaded == obj
+    return loaded

--- a/tests/test_objects/test_benefits/test_benefit.py
+++ b/tests/test_objects/test_benefits/test_benefit.py
@@ -1,84 +1,29 @@
-import numpy as np
+from pathlib import Path
+
 import pytest
 
+from flood_adapt.objects.benefits.benefits import CurrentSituationModel
 from flood_adapt.workflows.benefit_runner import Benefit
 
-_RAND = np.random.default_rng(2021)  # Value to make sure randomizing is always the same
-_TEST_NAMES = {
-    "benefit_with_costs": "benefit_raise_properties_2050",
-    "benefit_without_costs": "benefit_raise_properties_2050_no_costs",
-}
 
-_TEST_DICT = {
-    "name": "benefit_raise_properties_2080",
-    "description": "",
-    "event_set": "test_set",
-    "strategy": "elevate_comb_correct",
-    "projection": "all_projections",
-    "future_year": 2080,
-    "current_situation": {"projection": "current", "year": "2023"},
-    "baseline_strategy": "no_measures",
-    "discount_rate": 0.07,
-    "implementation_cost": 200000000,
-    "annual_maint_cost": 100000,
-}
-
-
-# Create Benefit object using example benefit toml in test database
-def test_loadfile_fromtestbenefittoml_createbenefit(test_db):
-    name = "benefit_raise_properties_2050"
-    benefit_path = test_db.input_path.joinpath(
-        "benefits",
-        name,
-        f"{name}.toml",
+@pytest.fixture
+def benefit():
+    return Benefit(
+        name="benefit_raise_properties_2080",
+        description="",
+        event_set="test_set",
+        strategy="elevate_comb_correct",
+        projection="all_projections",
+        future_year=2080,
+        current_situation=CurrentSituationModel(projection="current", year=2023),
+        baseline_strategy="no_measures",
+        discount_rate=0.07,
+        implementation_cost=200000000,
+        annual_maint_cost=100000,
     )
 
-    benefit = Benefit.load_file(benefit_path)
 
-    assert isinstance(benefit, Benefit)
-
-
-# Create Benefit object using using example benefit toml in test database to see if test with no costs is load normally
-def test_loadfile_fromtestbenefitnocoststoml_createbenefit(test_db):
-    name = "benefit_raise_properties_2050_no_costs"
-    benefit_path = test_db.input_path.joinpath(
-        "benefits",
-        name,
-        f"{name}.toml",
-    )
-
-    benefit = Benefit.load_file(benefit_path)
-
-    assert isinstance(benefit, Benefit)
-
-
-# Get FileNotFoundError when the path to the benefit toml does not exist
-def test_loadfile_nonexistingfile_filenotfounderror(test_db):
-    name = "benefit_raise_properties_2050_random"
-    benefit_path = test_db.input_path.joinpath(
-        "benefits",
-        name,
-        f"{name}.toml",
-    )
-
-    with pytest.raises(FileNotFoundError):
-        Benefit.load_file(benefit_path)
-
-
-# Create Benefit object using using a dictionary
-def test_loaddict_fromtestdict_createbenefit(test_db):
-    benefit = Benefit(**_TEST_DICT)
-    assert isinstance(benefit, Benefit)
-
-
-# Save a toml from a test benefit dictionary
-def test_save_fromtestdict_savetoml(test_db):
-    benefit = Benefit(**_TEST_DICT)
-    output_path = test_db.input_path.joinpath(
-        "benefits", "test_benefit", "test_benefit.toml"
-    )
-    if not output_path.parent.exists():
-        output_path.parent.mkdir()
-    assert not output_path.exists()
-    benefit.save(output_path)
-    assert output_path.exists()
+def test_benefit_save_and_load(benefit: Benefit, tmp_path: Path):
+    benefit.save(tmp_path / "benefit.toml")
+    loaded_benefit = Benefit.load_file(tmp_path / "benefit.toml")
+    assert benefit == loaded_benefit

--- a/tests/test_objects/test_events/test_historical.py
+++ b/tests/test_objects/test_events/test_historical.py
@@ -1,4 +1,3 @@
-import tempfile
 from datetime import timedelta
 from pathlib import Path
 
@@ -6,19 +5,16 @@ import pandas as pd
 import pytest
 
 from flood_adapt.config.hazard import RiverModel
-from flood_adapt.dbs_classes.interface.database import IDatabase
 from flood_adapt.objects.events.historical import (
     HistoricalEvent,
 )
 from flood_adapt.objects.forcing import unit_system as us
 from flood_adapt.objects.forcing.discharge import (
-    DischargeConstant,
     DischargeCSV,
 )
 from flood_adapt.objects.forcing.forcing import ForcingType
 from flood_adapt.objects.forcing.rainfall import (
     RainfallConstant,
-    RainfallMeteo,
 )
 from flood_adapt.objects.forcing.time_frame import (
     REFERENCE_TIME,
@@ -26,21 +22,18 @@ from flood_adapt.objects.forcing.time_frame import (
 )
 from flood_adapt.objects.forcing.waterlevels import (
     WaterlevelCSV,
-    WaterlevelModel,
 )
 from flood_adapt.objects.forcing.wind import (
     WindConstant,
-    WindMeteo,
 )
-from flood_adapt.objects.scenarios.scenarios import Scenario
 
 
 @pytest.fixture()
-def setup_nearshore_event(dummy_1d_timeseries_df: pd.DataFrame):
+def setup_nearshore_event(tmp_path: Path, dummy_1d_timeseries_df: pd.DataFrame):
     def _tmp_timeseries_csv(name: str):
-        tmp_csv = Path(tempfile.gettempdir()) / name
+        tmp_csv = tmp_path / name
         dummy_1d_timeseries_df.to_csv(tmp_csv)
-        return Path(tmp_csv)
+        return tmp_csv
 
     time = TimeFrame(
         start_time=REFERENCE_TIME, end_time=REFERENCE_TIME + timedelta(hours=2)
@@ -86,88 +79,28 @@ def setup_nearshore_event(dummy_1d_timeseries_df: pd.DataFrame):
     )
 
 
-@pytest.fixture()
-def setup_offshore_meteo_event():
-    time = TimeFrame(
-        start_time=REFERENCE_TIME, end_time=REFERENCE_TIME + timedelta(hours=2)
-    )
-    return HistoricalEvent(
-        name="offshore_meteo",
-        time=time,
-        forcings={
-            ForcingType.WATERLEVEL: [
-                WaterlevelModel(),
-            ],
-            ForcingType.WIND: [
-                WindMeteo(),
-            ],
-            ForcingType.RAINFALL: [
-                RainfallMeteo(),
-            ],
-            ForcingType.DISCHARGE: [
-                DischargeConstant(
-                    river=RiverModel(
-                        name="cooper",
-                        description="Cooper River",
-                        x_coordinate=595546.3,
-                        y_coordinate=3675590.6,
-                        mean_discharge=us.UnitfulDischarge(
-                            value=5000, units=us.UnitTypesDischarge.cfs
-                        ),
-                    ),
-                    discharge=us.UnitfulDischarge(
-                        value=5000, units=us.UnitTypesDischarge.cfs
-                    ),
-                ),
-            ],
-        },
-    )
+def test_save_additional_csv(setup_nearshore_event: HistoricalEvent, tmp_path: Path):
+    # Arrange
+    path = tmp_path / "test_event.toml"
+    event = setup_nearshore_event
+    expected_csvs = [
+        path.parent / "waterlevel.csv",
+        path.parent / "discharge.csv",
+    ]
+
+    # Act
+    event.save(toml_path=path)
+
+    # Assert
+    assert all(csv.exists() for csv in expected_csvs)
 
 
-@pytest.fixture()
-def setup_offshore_scenario(
-    setup_offshore_meteo_event: HistoricalEvent, test_db: IDatabase
-):
-    return Scenario(
-        name="offshore_meteo",
-        event=setup_offshore_meteo_event.name,
-        projection="current",
-        strategy="no_measures",
-    )
+def test_save_and_load(setup_nearshore_event: HistoricalEvent, tmp_path: Path):
+    path = tmp_path / "test_event.toml"
+    saved_event = setup_nearshore_event
+    saved_event.save(path)
+    assert path.exists()
 
+    loaded_event = HistoricalEvent.load_file(path)
 
-class TestHistoricalEvent:
-    def test_save_event_toml(
-        self, setup_nearshore_event: HistoricalEvent, tmp_path: Path
-    ):
-        path = tmp_path / "test_event.toml"
-        event = setup_nearshore_event
-        event.save(path)
-        assert path.exists()
-
-    def test_save_additional_csv(
-        self, setup_nearshore_event: HistoricalEvent, tmp_path: Path
-    ):
-        # Arrange
-        path = tmp_path / "test_event.toml"
-        event = setup_nearshore_event
-        expected_csvs = [
-            path.parent / "waterlevel.csv",
-            path.parent / "discharge.csv",
-        ]
-
-        # Act
-        event.save_additional(output_dir=path.parent)
-
-        # Assert
-        assert all(csv.exists() for csv in expected_csvs)
-
-    def test_load_file(self, setup_nearshore_event: HistoricalEvent, tmp_path: Path):
-        path = tmp_path / "test_event.toml"
-        saved_event = setup_nearshore_event
-        saved_event.save(path)
-        assert path.exists()
-
-        loaded_event = HistoricalEvent.load_file(path)
-
-        assert loaded_event == saved_event
+    assert loaded_event == saved_event

--- a/tests/test_objects/test_events/test_hurricane.py
+++ b/tests/test_objects/test_events/test_hurricane.py
@@ -1,10 +1,8 @@
-import tempfile
 from pathlib import Path
 
 import pytest
 
 from flood_adapt.config.hazard import RiverModel
-from flood_adapt.dbs_classes.interface.database import IDatabase
 from flood_adapt.objects.events.events import (
     ForcingType,
 )
@@ -21,7 +19,6 @@ from flood_adapt.objects.forcing.waterlevels import (
     WaterlevelModel,
 )
 from flood_adapt.objects.forcing.wind import WindTrack
-from flood_adapt.objects.scenarios.scenarios import Scenario
 from tests.fixtures import TEST_DATA_DIR
 
 
@@ -57,79 +54,38 @@ def setup_hurricane_event() -> tuple[HurricaneEvent, Path]:
     return event
 
 
-@pytest.fixture()
-def setup_hurricane_scenario(
-    test_db: IDatabase, setup_hurricane_event: HurricaneEvent
-) -> tuple[Scenario, HurricaneEvent]:
+def test_save_and_load(setup_hurricane_event: HurricaneEvent, tmp_path: Path):
+    path = tmp_path / "test_event.toml"
     event = setup_hurricane_event
-    scn = Scenario(
-        name="test_scenario",
-        event=event.name,
-        projection="current",
-        strategy="no_measures",
-    )
-    test_db.events.save(event)
-    test_db.scenarios.save(scn)
-    return scn, event
+
+    event.save(path)
+
+    cyc_file = path.parent / f"{event.track_name}.cyc"
+    assert path.exists()
+    assert cyc_file.exists()
+
+    loaded_event = HurricaneEvent.load_file(path)
+    assert loaded_event == event
 
 
-class TestHurricaneEvent:
-    def test_save_event_toml_and_track_file(
-        self, setup_hurricane_event: HurricaneEvent, tmp_path: Path
-    ):
-        path = tmp_path / "test_event.toml"
-        event = setup_hurricane_event
+def test_load_file_raises_when_files_are_missing(
+    setup_hurricane_event: HurricaneEvent, tmp_path: Path
+):
+    path = tmp_path / "test_event.toml"
 
-        event.save(path)
+    saved_event = setup_hurricane_event
+    saved_event.save(path)
+    wind = saved_event.forcings[ForcingType.WIND][0]
+    assert isinstance(wind, WindTrack)
 
-        cyc_file = path.parent / f"{event.track_name}.cyc"
-        assert path.exists()
-        assert cyc_file.exists()
+    cyc_file = path.parent / wind.path
 
-    def test_load_file(self, setup_hurricane_event: HurricaneEvent, tmp_path: Path):
-        path = tmp_path / "test_event.toml"
-        saved_event = setup_hurricane_event
-        saved_event.save(path)
-        cyc_file = path.parent / f"{saved_event.track_name}.cyc"
-        assert path.exists()
-        assert cyc_file.exists()
+    assert path.exists()
+    assert cyc_file.exists()
 
-        loaded_event = HurricaneEvent.load_file(path)
+    cyc_file.unlink()
 
-        assert loaded_event == saved_event
+    with pytest.raises(FileNotFoundError) as e:
+        HurricaneEvent.load_file(path)
 
-    def test_load_file_raises_when_files_are_missing(
-        self, setup_hurricane_event: HurricaneEvent, tmp_path: Path
-    ):
-        path = tmp_path / "test_event.toml"
-
-        saved_event = setup_hurricane_event
-        saved_event.save(path)
-        wind = saved_event.forcings[ForcingType.WIND][0]
-        assert isinstance(wind, WindTrack)
-
-        cyc_file = path.parent / wind.path
-
-        assert path.exists()
-        assert cyc_file.exists()
-
-        cyc_file.unlink()
-
-        with pytest.raises(FileNotFoundError) as e:
-            HurricaneEvent.load_file(path)
-
-        assert f"File {cyc_file} does not exist" in str(e.value)
-
-    def test_save_additional_saves_cyc_file(
-        self, setup_hurricane_event: HurricaneEvent
-    ):
-        # Arrange
-        event = setup_hurricane_event
-        toml_path = Path(tempfile.gettempdir()) / "test_event.toml"
-
-        # Act
-        event.save_additional(toml_path.parent)
-
-        # Assert
-        cyc_file = toml_path.parent / f"{event.track_name}.cyc"
-        assert cyc_file.exists()
+    assert f"File {cyc_file} does not exist" in str(e.value)

--- a/tests/test_objects/test_events/test_synthetic.py
+++ b/tests/test_objects/test_events/test_synthetic.py
@@ -3,9 +3,7 @@ from datetime import datetime
 import pytest
 
 from flood_adapt.config.hazard import RiverModel
-from flood_adapt.objects.events.synthetic import (
-    SyntheticEvent,
-)
+from flood_adapt.objects.events.synthetic import SyntheticEvent
 from flood_adapt.objects.forcing import unit_system as us
 from flood_adapt.objects.forcing.discharge import DischargeConstant
 from flood_adapt.objects.forcing.forcing import ForcingType
@@ -23,6 +21,7 @@ from flood_adapt.objects.forcing.waterlevels import (
     WaterlevelSynthetic,
 )
 from flood_adapt.objects.forcing.wind import WindConstant
+from tests.test_objects import assert_object_save_load_eq
 
 
 @pytest.fixture()
@@ -98,20 +97,5 @@ def test_event_all_synthetic():
     )
 
 
-class TestSyntheticEvent:
-    # TODO add test for for eventmodel validators
-    def test_save_event_toml(self, test_event_all_synthetic, tmp_path):
-        path = tmp_path / "test_event.toml"
-        test_event = test_event_all_synthetic
-        test_event.save(path)
-        assert path.exists()
-
-    def test_load_file(self, test_event_all_synthetic, tmp_path):
-        path = tmp_path / "test_event.toml"
-        saved_event = test_event_all_synthetic
-        saved_event.save(path)
-        assert path.exists()
-
-        loaded_event = SyntheticEvent.load_file(path)
-
-        assert loaded_event == saved_event
+def test_synthetic_event_save_load_eq(tmp_path, test_event_all_synthetic):
+    assert_object_save_load_eq(tmp_path, test_event_all_synthetic, SyntheticEvent)

--- a/tests/test_objects/test_forcing/test_timeseries.py
+++ b/tests/test_objects/test_forcing/test_timeseries.py
@@ -561,7 +561,7 @@ class TestBlock:
 
 
 class TestTriangle:
-    _TEST_ATTRS = permutations([1, 10, 100, 1000], r=3)
+    _TEST_ATTRS = permutations([1, 10, 100], r=3)
 
     @pytest.mark.parametrize(
         "cumulative, duration, time_step",

--- a/tests/test_objects/test_forcing/test_waterlevels.py
+++ b/tests/test_objects/test_forcing/test_waterlevels.py
@@ -220,7 +220,7 @@ class TestWaterlevelModel:
             },
         )
 
-        test_db.events.save(event)
+        test_db.events.add(event)
 
         scn = Scenario(
             name="test_scenario",
@@ -228,6 +228,6 @@ class TestWaterlevelModel:
             projection="current",
             strategy="no_measures",
         )
-        test_db.scenarios.save(scn)
+        test_db.scenarios.add(scn)
 
         return test_db, scn, event

--- a/tests/test_objects/test_projections/test_projections.py
+++ b/tests/test_objects/test_projections/test_projections.py
@@ -2,51 +2,11 @@ from pathlib import Path
 
 import pytest
 
-from flood_adapt.misc.io import read_toml
-from flood_adapt.objects.forcing import unit_system as us
 from flood_adapt.objects.projections.projections import (
     PhysicalProjection,
     Projection,
     SocioEconomicChange,
 )
-
-
-@pytest.fixture()
-def test_projections(test_db) -> dict[str, Projection]:
-    test_tomls = [
-        test_db.input_path / "projections" / "all_projections" / "all_projections.toml",
-        test_db.input_path / "projections" / "SLR_2ft" / "SLR_2ft.toml",
-    ]
-    test_projections = {
-        toml_file.name: Projection.load_file(toml_file) for toml_file in test_tomls
-    }
-    yield test_projections
-
-
-@pytest.fixture()
-def test_dict(test_data_dir):
-    config_values = {
-        "name": "new_projection",
-        "description": "new_unsaved_projection",
-        "physical_projection": {
-            "sea_level_rise": {"value": 2, "units": "feet"},
-            "subsidence": {"value": 0, "units": "feet"},
-            "rainfall_multiplier": 20,
-            "storm_frequency_increase": 20,
-        },
-        "socio_economic_change": {
-            "economic_growth": 20,
-            "population_growth_new": 20,
-            "population_growth_existing": 20,
-            "new_development_elevation": {
-                "value": 1,
-                "units": "feet",
-                "type": "floodmap",
-            },
-            "new_development_shapefile": str(Path(test_data_dir, "new_areas.geojson")),
-        },
-    }
-    yield config_values
 
 
 @pytest.fixture
@@ -61,113 +21,6 @@ def test_projection(test_data_dir):
             )
         ),
     )
-
-
-def test_projection_load_dict(test_dict):
-    projection = Projection(**test_dict)
-    for key, value in test_dict.items():
-        if not isinstance(value, dict):
-            assert getattr(projection, key) == value
-
-
-def test_projection_save_createsFile(test_db, test_dict):
-    test_projection = Projection(**test_dict)
-    file_path = (
-        test_db.input_path / "projections" / "new_projection" / "new_projection.toml"
-    )
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    test_projection.save(file_path)
-    assert file_path.is_file()
-
-
-def test_projection_loadFile_checkAllAttrs(test_db, test_dict):
-    test_projection = Projection(**test_dict)
-    file_path = (
-        test_db.input_path / "projections" / "new_projection" / "new_projection.toml"
-    )
-    file_path.parent.mkdir(parents=True, exist_ok=True)
-    test_projection.save(file_path)
-
-    test_projection = Projection.load_file(file_path)
-    for key, value in test_dict.items():
-        if not isinstance(value, dict):
-            assert getattr(test_projection, key) == value
-
-
-def test_projection_loadFile_validFiles(test_projections: dict[str, Projection]):
-    test_projection = test_projections["all_projections.toml"]
-    # Assert that the configured risk drivers are set to the values from the toml file
-    assert isinstance(test_projection.physical_projection, PhysicalProjection)
-    assert isinstance(test_projection.socio_economic_change, SocioEconomicChange)
-
-
-def test_projection_loadFile_invalidFile_raiseFileNotFoundError():
-    with pytest.raises(FileNotFoundError):
-        Projection.load_file(Path("invalid_file.toml"))
-
-
-def test_projection_getPhysicalProjection_readValidAttrs(
-    test_projections: dict[str, Projection],
-):
-    test_projection = test_projections["all_projections.toml"]
-
-    assert test_projection.name == "all_projections"
-    physical_attrs = test_projection.physical_projection
-
-    assert physical_attrs.sea_level_rise.value == 2
-    assert physical_attrs.sea_level_rise.units == us.UnitTypesLength.feet
-
-    assert physical_attrs.subsidence.value == 0
-    assert physical_attrs.subsidence.units == us.UnitTypesLength.meters
-
-    assert physical_attrs.rainfall_multiplier == 2
-    assert physical_attrs.storm_frequency_increase == 2
-
-
-def test_projection_getSocioEconomicChange_readValidAttrs(
-    test_projections: dict[str, Projection],
-):
-    test_projection = test_projections["all_projections.toml"]
-
-    assert test_projection.name == "all_projections"
-
-    socio_economic_attrs = test_projection.socio_economic_change
-
-    assert socio_economic_attrs.economic_growth == 20
-    assert socio_economic_attrs.population_growth_new == 20
-    assert socio_economic_attrs.population_growth_existing == 20
-    assert socio_economic_attrs.new_development_elevation.value == 1
-    assert socio_economic_attrs.new_development_elevation.units == "feet"
-    assert socio_economic_attrs.new_development_elevation.type == "floodmap"
-    assert socio_economic_attrs.new_development_shapefile == "new_areas.geojson"
-
-
-def test_projection_getSocioEconomicChange_readInvalidAttrs_raiseAttributeError(
-    test_projections: dict[str, Projection],
-):
-    test_projection = test_projections["all_projections.toml"]
-    with pytest.raises(AttributeError):
-        test_projection.socio_economic_change.sea_level_rise.value
-
-
-def test_projection_getPhysicalProjection_readInvalidAttrs_raiseAttributeError(
-    test_projections,
-):
-    test_projection = test_projections["all_projections.toml"]
-    with pytest.raises(AttributeError):
-        test_projection.physical_projection.economic_growth
-
-
-def test_projection_only_slr(test_projections: dict[str, Projection]):
-    test_projection = test_projections["SLR_2ft.toml"]
-
-    # Assert that all unconfigured risk drivers are set to the default values
-    assert test_projection.physical_projection.storm_frequency_increase == 0
-
-    # Assert that the configured risk drivers are set to the values from the toml file
-    assert test_projection.name == "SLR_2ft"
-    assert test_projection.physical_projection.sea_level_rise.value == 2
-    assert test_projection.physical_projection.sea_level_rise.units == "feet"
 
 
 def test_save_with_new_development_areas_also_saves_shapefile(
@@ -186,38 +39,10 @@ def test_save_with_new_development_areas_also_saves_shapefile(
     # Assert
     assert toml_path.exists()
     assert expected_new_path.exists()
-    data = read_toml(toml_path)
+
+    loaded = Projection.load_file(toml_path)
+    assert loaded == test_projection
     assert (
-        data["socio_economic_change"]["new_development_shapefile"]
-        == expected_new_path.name
-    )
-
-
-def test_save_with_new_development_areas_shapefile_already_exists(
-    test_projection, test_db
-):
-    # Arrange
-    toml_path = (
-        test_db.input_path
-        / "projections"
-        / test_projection.name
-        / f"{test_projection.name}.toml"
-    )
-    expected_new_path = (
-        toml_path.parent
-        / Path(
-            test_projection.socio_economic_change.new_development_shapefile  # "pop_growth_new_20.shp"
-        ).name
-    )
-
-    # Act
-    test_projection.save(toml_path)
-    test_projection.save(toml_path)
-
-    # Assert
-    assert toml_path.exists()
-    assert expected_new_path.exists()
-    assert (
-        test_projection.socio_economic_change.new_development_shapefile
-        == expected_new_path.name
+        loaded.socio_economic_change.new_development_shapefile
+        == expected_new_path.as_posix()
     )

--- a/tests/test_objects/test_scenarios/test_scenarios.py
+++ b/tests/test_objects/test_scenarios/test_scenarios.py
@@ -1,0 +1,25 @@
+import pytest
+
+from flood_adapt.objects.scenarios.scenarios import Scenario
+
+
+@pytest.fixture
+def test_scenario():
+    return Scenario(
+        name="test_projection",
+        event="test_event",
+        projection="test_projection",
+        strategy="test_strategy",
+    )
+
+
+def test_save_load_eq(test_scenario, tmp_path):
+    # Arrange
+    toml_path = tmp_path / "test_file.toml"
+
+    # Act
+    test_scenario.save(toml_path)
+    loaded = Scenario.load_file(toml_path)
+
+    # Assert
+    assert loaded == test_scenario

--- a/tests/test_objects/test_strategies/test_strategies.py
+++ b/tests/test_objects/test_strategies/test_strategies.py
@@ -3,111 +3,72 @@ from unittest.mock import patch
 import pytest
 
 from flood_adapt.misc.exceptions import DatabaseError
+from flood_adapt.objects import Strategy
 from flood_adapt.objects.measures.measures import (
-    Buyout,
-    Elevate,
-    FloodProof,
-    FloodWall,
-    GreenInfrastructure,
     HazardMeasure,
     ImpactMeasure,
     MeasureType,
-    SelectionType,
 )
-from flood_adapt.objects.strategies.strategies import Strategy
+from tests.test_objects.test_measures.test_measures import (
+    test_buyout,
+    test_elevate,
+    test_floodproof,
+    test_floodwall,
+    test_green_infra,
+    test_pump,
+)
+
+__all__ = [
+    "test_buyout",
+    "test_elevate",
+    "test_floodproof",
+    "test_floodwall",
+    "test_green_infra",
+    "test_pump",
+]
 
 
 @pytest.fixture()
-def test_attrs():
-    strat_attrs = {
-        "name": "new_strategy",
-        "description": "new_unsaved_strategy",
-        "measures": [
-            "seawall",
-            "raise_property_aggregation_area",
-            "buyout",
-            "floodproof",
-        ],
-    }
-    yield strat_attrs
+def strategy_no_measures() -> Strategy:
+    s = Strategy(
+        name="no_measures",
+        description="test strategy with no measures",
+        measures=[],
+    )
+    s.initialize_measure_objects(measures=[])
+    return s
 
 
 @pytest.fixture()
-def test_seawall():
-    attrs = {
-        "name": "seawall",
-        "description": "seawall",
-        "type": "floodwall",
-        "selection_type": "polygon",
-        "polygon_file": "seawall.geojson",
-        "elevation": {
-            "value": 12,
-            "units": "feet",
-        },
-    }
-    return attrs
+def test_strategy(
+    test_elevate,
+    test_buyout,
+    test_floodproof,
+    test_floodwall,
+    test_green_infra,
+    test_pump,
+) -> Strategy:
+    measure_objs = [
+        test_elevate,
+        test_buyout,
+        test_floodproof,
+        test_floodwall,
+        test_green_infra,
+        test_pump,
+    ]
+    s = Strategy(
+        name="strategy_comb",
+        description="test strategy with both hazard and impact measures",
+        measures=[measure.name for measure in measure_objs],
+    )
+    s.initialize_measure_objects(measures=measure_objs)
+    return s
 
 
-@pytest.fixture()
-def test_raise_property_aggregation_area():
-    attrs = {
-        "name": "raise_property_aggregation_area",
-        "description": "raise_property_aggregation_area",
-        "type": "elevate_properties",
-        "elevation": {
-            "value": 1,
-            "units": "feet",
-            "type": "floodmap",
-        },
-        "selection_type": "aggregation_area",
-        "aggregation_area_type": "aggr_lvl_2",
-        "aggregation_area_name": "name5",
-        "property_type": "RES",
-    }
-    return attrs
-
-
-@pytest.fixture()
-def test_buyout():
-    attrs = {
-        "name": "buyout",
-        "description": "buyout",
-        "type": "buyout_properties",
-        "selection_type": "aggregation_area",
-        "aggregation_area_type": "aggr_lvl_2",
-        "aggregation_area_name": "name1",
-        "property_type": "RES",
-    }
-    return attrs
-
-
-@pytest.fixture()
-def test_floodproof():
-    attrs = {
-        "name": "floodproof",
-        "description": "floodproof",
-        "type": "floodproof_properties",
-        "selection_type": "aggregation_area",
-        "aggregation_area_type": "aggr_lvl_2",
-        "aggregation_area_name": "name3",
-        "elevation": {
-            "value": 3,
-            "units": "feet",
-        },
-        "property_type": "RES",
-    }
-    return attrs
-
-
-@pytest.fixture()
-def test_strategy(test_db) -> Strategy:
-    return test_db.strategies.get("strategy_comb")
-
-
-def test_strategy_comb_read(test_db, test_strategy: Strategy):
+def test_strategy_save_load_eq(tmp_path, test_strategy: Strategy):
     strategy = test_strategy
     assert strategy.name == "strategy_comb"
-    assert len(strategy.measures) == 4
+    assert len(strategy.measures) == 6
 
     impact_strategy = strategy.get_impact_strategy()
     impact_measures = strategy.get_impact_measures()
@@ -116,9 +77,6 @@ def test_strategy_comb_read(test_db, test_strategy: Strategy):
     for measure in impact_measures:
         assert MeasureType.is_impact(measure.type)
         assert isinstance(measure, ImpactMeasure)
-    assert isinstance(impact_measures[0], Elevate)
-    assert isinstance(impact_measures[1], Buyout)
-    assert isinstance(impact_measures[2], FloodProof)
 
     hazard_strategy = strategy.get_hazard_strategy()
     hazard_measures = strategy.get_hazard_measures()
@@ -127,11 +85,15 @@ def test_strategy_comb_read(test_db, test_strategy: Strategy):
     for measure in strategy.get_hazard_measures():
         assert MeasureType.is_hazard(measure.type)
         assert isinstance(measure, HazardMeasure)
-    assert isinstance(hazard_measures[0], FloodWall)
+
+    path = tmp_path / (test_strategy.name + ".toml")
+    strategy.save(path)
+    loaded = Strategy.load_file(path)
+    assert loaded == strategy
 
 
-def test_strategy_no_measures(test_db):
-    strategy: Strategy = test_db.strategies.get("no_measures")
+def test_strategy_no_measures(strategy_no_measures: Strategy):
+    strategy = strategy_no_measures
     assert len(strategy.measures) == 0
     assert isinstance(strategy.get_hazard_strategy(), Strategy)
     assert isinstance(strategy.get_impact_strategy(), Strategy)
@@ -139,54 +101,22 @@ def test_strategy_no_measures(test_db):
     assert len(strategy.get_impact_strategy().measures) == 0
 
 
-def test_elevate_comb_correct(test_db):
-    strategy: Strategy = test_db.strategies.get("elevate_comb_correct")
-    impact_measures = strategy.get_impact_measures()
-
-    assert strategy.name == "elevate_comb_correct"
-    assert isinstance(impact_measures, list)
-    assert isinstance(strategy.measures, list)
-    assert isinstance(impact_measures[0], Elevate)
-    assert isinstance(impact_measures[1], Elevate)
-
-
-def test_green_infra(test_db):
-    strategy: Strategy = test_db.strategies.get("greeninfra")
-
-    assert strategy.name == "greeninfra"
-    assert isinstance(strategy.measures, list)
-
-    hazard_measures = strategy.get_hazard_measures()
-    assert isinstance(hazard_measures, list)
-
-    assert isinstance(hazard_measures[0], GreenInfrastructure)
-    assert isinstance(hazard_measures[1], GreenInfrastructure)
-    assert isinstance(hazard_measures[2], GreenInfrastructure)
-
-
 @pytest.fixture()
-def setup_strategy_with_overlapping_measures(test_db, test_data_dir):
+def setup_strategy_with_overlapping_measures(test_db, test_buyout):
     measures = []
     for i in range(1, 4):
-        attrs = {
-            "name": f"test_buyout{i}",
-            "description": "test_buyout",
-            "type": MeasureType.buyout_properties,
-            "selection_type": SelectionType.polygon,
-            "property_type": "RES",
-            "polygon_file": str(test_data_dir / "polygon.geojson"),
-        }
-        test_buyout = Buyout(**attrs)
+        measure = test_buyout.model_copy(deep=True)
+        measure.name = f"test_buyout_{i}"
+        measures.append(measure)
+        test_db.measures.add(measure)
 
-        measures.append(test_buyout.name)
-        test_db.measures.save(test_buyout)
-
-    strategy_model = {
-        "name": "test_strategy",
-        "description": "test_strategy",
-        "measures": measures,
-    }
-    return test_db, Strategy(**strategy_model)
+    strategy = Strategy(
+        name="test_strategy",
+        description="test_strategy",
+        measures=[measure.name for measure in measures],
+    )
+    strategy.initialize_measure_objects(measures=measures)
+    return test_db, strategy
 
 
 @patch("flood_adapt.adapter.fiat_adapter.FiatAdapter.get_object_ids")
@@ -197,7 +127,7 @@ def test_check_overlapping_measures(
     mock_get_object_ids.return_value = [1, 2, 3]
 
     with pytest.raises(DatabaseError) as excinfo:
-        test_db.strategies._check_overlapping_measures(strategy.measures)
+        test_db.strategies._assert_no_overlapping_measures(strategy.measures)
 
     assert (
         "Cannot create strategy! There are overlapping buildings for which measures are proposed"

--- a/tests/test_workflows/test_benefit_runner.py
+++ b/tests/test_workflows/test_benefit_runner.py
@@ -1,5 +1,3 @@
-import shutil
-
 import geopandas as gpd
 import numpy as np
 import pandas as pd
@@ -8,7 +6,12 @@ import pytest
 from flood_adapt.dbs_classes.interface.database import IDatabase
 from flood_adapt.misc.io import read_toml
 from flood_adapt.workflows.benefit_runner import Benefit, BenefitRunner
-from tests.test_objects.test_benefits.test_benefit import _RAND, _TEST_NAMES
+
+_RAND = np.random.default_rng(2021)  # Value to make sure randomizing is always the same
+_TEST_NAMES = {
+    "benefit_with_costs": "benefit_raise_properties_2050",
+    "benefit_without_costs": "benefit_raise_properties_2050_no_costs",
+}
 
 
 # Tests for when the scenarios needed for the benefit analysis are not there yet
@@ -87,12 +90,11 @@ class TestBenefitScenariosNotCreated:
         self, benefit_obj_and_runner: tuple[Benefit, BenefitRunner]
     ):
         benefit_obj, runner = benefit_obj_and_runner
-        # Delete one of the scenarios
-        to_delete = (
-            runner.database.scenarios.input_path
-            / runner.scenarios["scenario created"][0]
+
+        # Delete the scenarios like this. calling `delete` will raise IsUsedInError
+        runner.database.scenarios._objects.pop(
+            runner.scenarios["scenario created"][0], None
         )
-        shutil.rmtree(to_delete)
 
         with pytest.raises(RuntimeError) as exception_info:
             runner.run_cost_benefit()

--- a/tests/test_workflows/test_scenario_runner.py
+++ b/tests/test_workflows/test_scenario_runner.py
@@ -7,6 +7,9 @@ from flood_adapt.workflows.scenario_runner import Scenario, ScenarioRunner
 from tests.conftest import IS_WINDOWS
 from tests.test_objects.test_events.test_hurricane import setup_hurricane_event
 
+# mark all tests in this module as integration tests
+pytestmark = pytest.mark.integration
+
 __all__ = ["setup_hurricane_event"]
 
 
@@ -55,8 +58,8 @@ class Test_scenario_run:
             projection="current",
             strategy="no_measures",
         )
-        test_db.events.save(event)
-        test_db.scenarios.save(scn)
+        test_db.events.add(event)
+        test_db.scenarios.add(scn)
         return test_db, scn, event
 
     def test_run_hurricane_scenario(


### PR DESCRIPTION

## Issue addressed
Fixes #951 

## Explanation

When flushing the database, we first write to tmp_dir to allow for copying over relevant files before deleting them.

This is not a great solution since we are writing, and then moving instead of just a single write. 
Note that `shutil.move(src, dst)` actually just renames the files when the moving to the same drive. (i.e. `C:/`).
It only copies when the drives are not equal. 

This will no longer be necessary when all the objects read in their data from the files, instead of only keeping track of the filepath. 
Ideally, the db would read in the object and its data, then allow for edits to the object in memory, then delete the old object on disk, and write the updated object to disk. But that is out of scope for this PR.

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `main`
- [ ] Updated documentation if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
