### PR TITLE
fix(misc): Replace DEM tile pyramids with single GeoTIFFs + harden infographic errors

### DIFF
--- a/flood_adapt/adapter/fiat_adapter.py
+++ b/flood_adapt/adapter/fiat_adapter.py
@@ -1286,13 +1286,33 @@ class FiatAdapter(IImpactAdapter):
                 return
 
         # Get the infographic
-        InforgraphicFactory.create_infographic_file_writer(
-            infographic_mode=mode,
-            scenario_name=name,
-            metrics_full_path=metrics_path,
-            config_base_path=config_base_path,
-            output_base_path=output_base_path,
-        ).write_infographics_to_file()
+        try:
+            InforgraphicFactory.create_infographic_file_writer(
+                infographic_mode=mode,
+                scenario_name=name,
+                metrics_full_path=metrics_path,
+                config_base_path=config_base_path,
+                output_base_path=output_base_path,
+            ).write_infographics_to_file()
+        except KeyError as e:
+            missing_key = e.args[0] if e.args else str(e)
+            if missing_key == "query":
+                raise KeyError(
+                    "Failed to create the risk infographic. The configuration file "
+                    f"'config_risk_charts.toml' in '{config_base_path}' is missing a "
+                    "'query' field in the [Other.Expected_Damages] and/or [Other.Flooded] "
+                    "sections. This field is required by the installed fiat_toolbox version "
+                    "and must contain the metric name to display, e.g.:\n"
+                    '    [Other.Expected_Damages]\n        query = "ExpectedAnnualDamages"\n'
+                    '    [Other.Flooded]\n        query = "FloodedHomes"\n'
+                    "Add these lines to make the database compatible."
+                ) from e
+            raise KeyError(
+                f"Failed to create the infographic. The metric '{missing_key}' referenced in "
+                f"the infographic configuration in '{config_base_path}' was not found in the "
+                f"metrics file '{metrics_path}'. Check that the 'query' values in "
+                "'config_risk_charts.toml' match the metric names produced for this scenario."
+            ) from e
 
     def add_equity(
         self,

--- a/flood_adapt/adapter/fiat_adapter.py
+++ b/flood_adapt/adapter/fiat_adapter.py
@@ -1286,33 +1286,13 @@ class FiatAdapter(IImpactAdapter):
                 return
 
         # Get the infographic
-        try:
-            InforgraphicFactory.create_infographic_file_writer(
-                infographic_mode=mode,
-                scenario_name=name,
-                metrics_full_path=metrics_path,
-                config_base_path=config_base_path,
-                output_base_path=output_base_path,
-            ).write_infographics_to_file()
-        except KeyError as e:
-            missing_key = e.args[0] if e.args else str(e)
-            if missing_key == "query":
-                raise KeyError(
-                    "Failed to create the risk infographic. The configuration file "
-                    f"'config_risk_charts.toml' in '{config_base_path}' is missing a "
-                    "'query' field in the [Other.Expected_Damages] and/or [Other.Flooded] "
-                    "sections. This field is required by the installed fiat_toolbox version "
-                    "and must contain the metric name to display, e.g.:\n"
-                    '    [Other.Expected_Damages]\n        query = "ExpectedAnnualDamages"\n'
-                    '    [Other.Flooded]\n        query = "FloodedHomes"\n'
-                    "Add these lines to make the database compatible."
-                ) from e
-            raise KeyError(
-                f"Failed to create the infographic. The metric '{missing_key}' referenced in "
-                f"the infographic configuration in '{config_base_path}' was not found in the "
-                f"metrics file '{metrics_path}'. Check that the 'query' values in "
-                "'config_risk_charts.toml' match the metric names produced for this scenario."
-            ) from e
+        InforgraphicFactory.create_infographic_file_writer(
+            infographic_mode=mode,
+            scenario_name=name,
+            metrics_full_path=metrics_path,
+            config_base_path=config_base_path,
+            output_base_path=output_base_path,
+        ).write_infographics_to_file()
 
     def add_equity(
         self,

--- a/flood_adapt/config/hazard.py
+++ b/flood_adapt/config/hazard.py
@@ -112,9 +112,12 @@ class DemModel(BaseModel):
         The path to the digital elevation model file.
     units : us.UnitTypesLength
         The units of the digital elevation model file.
+    index_file : str, default="index.tif"
+        The path to the index file for the digital elevation model file.
     """
 
     filename: str
+    index_file: str = "index.tif"
     units: us.UnitTypesLength
 
 

--- a/flood_adapt/database_builder/database_builder.py
+++ b/flood_adapt/database_builder/database_builder.py
@@ -2,7 +2,6 @@ import datetime
 import gc
 import logging
 import math
-import os
 import re
 import shutil
 import warnings
@@ -1420,31 +1419,25 @@ class DatabaseBuilder:
         fa_subgrid_path = self.static_path / "dem" / dem_file.name
         fa_subgrid_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Check tiles
-        tiles_sfincs = Path(self.sfincs_overland_model.root) / "tiles"
-        fa_tiles_path = self.static_path / "dem" / "tiles"
-        if tiles_sfincs.exists():
-            shutil.move(tiles_sfincs, fa_tiles_path)
-            if (fa_tiles_path / "index").exists():
-                os.rename(fa_tiles_path / "index", fa_tiles_path / "indices")
-            logger.info(
-                "Tiles were already available in the SFINCS model and will directly be used in FloodAdapt."
-            )
-        else:
-            # Make tiles
-            fa_tiles_path.mkdir(parents=True)
-            self.sfincs_overland_model.setup_tiles(
-                path=fa_tiles_path,
-                datasets_dep=[{"elevtn": dem_file}],
-                zoom_range=[0, 13],
-                fmt="png",
-            )
-            logger.info(
-                f"Tiles were created using the {subgrid_sfincs.as_posix()} as the elevation map."
-            )
-
         shutil.copy2(dem_file, fa_subgrid_path)
         self._dem_path = fa_subgrid_path
+
+        # Create the index GeoTIFF that maps each high-resolution DEM pixel to its
+        # SFINCS grid cell. The GUI (Guitares image overlays via cht_tiling) renders
+        # topography and flood maps from the single DEM GeoTIFF + this index.tif,
+        # so we no longer build the deprecated PNG tile pyramids.
+        from hydromt_sfincs.workflows.downscaling import make_index_cog
+
+        index_path = self.static_path / "dem" / "index.tif"
+        make_index_cog(
+            model=self.sfincs_overland_model,
+            indices_fn=index_path,
+            topobathy_fn=fa_subgrid_path.as_posix(),
+        )
+        logger.info(
+            f"Index GeoTIFF was created at {index_path.as_posix()} using "
+            f"{subgrid_sfincs.as_posix()} as the elevation map."
+        )
 
         # Remove the original subgrid folder if it exists
         if delete_sfincs_folder:

--- a/flood_adapt/database_builder/database_builder.py
+++ b/flood_adapt/database_builder/database_builder.py
@@ -1446,7 +1446,9 @@ class DatabaseBuilder:
                 shutil.rmtree(subgrid_sfincs_folder)
 
         return DemModel(
-            filename=fa_subgrid_path.name, units=us.UnitTypesLength.meters
+            filename=fa_subgrid_path.name,
+            units=us.UnitTypesLength.meters,
+            index_file=index_path.name,
         )  # always in meters
 
     @debug_timer

--- a/flood_adapt/dbs_classes/database.py
+++ b/flood_adapt/dbs_classes/database.py
@@ -332,10 +332,10 @@ class Database(IDatabase):
             try:
                 self._generate_index_geotiff(index_path)
             except Exception as e:
-                logger.warning(
+                raise DatabaseError(
                     f"Could not generate the index GeoTIFF at {index_path.as_posix()}: "
                     f"{e}. The flood map will not render until it is available."
-                )
+                ) from e
 
         # 2. Remove the deprecated tile pyramids.
         if tiles_dir.exists():
@@ -362,7 +362,9 @@ class Database(IDatabase):
         from hydromt_sfincs import SfincsModel as HydromtSfincsModel
         from hydromt_sfincs.workflows.downscaling import make_index_cog
 
-        overland_root = self.static_path / "templates" / "overland"
+        overland_root = (
+            self.static_path / "templates" / self.site.sfincs.config.overland_model.name
+        )
         logger.info(
             f"Generating index GeoTIFF at {index_path.as_posix()} from SFINCS model "
             f"{overland_root.as_posix()} ..."

--- a/flood_adapt/dbs_classes/database.py
+++ b/flood_adapt/dbs_classes/database.py
@@ -410,7 +410,8 @@ class Database(IDatabase):
         Returns
         -------
         np.array
-            2D map of maximum water levels
+            1D per-cell array of maximum water levels,
+            matching the cell numbering of the index GeoTIFF
         """
         # If single event read with hydromt-sfincs
         if not return_period:

--- a/flood_adapt/dbs_classes/database.py
+++ b/flood_adapt/dbs_classes/database.py
@@ -307,8 +307,7 @@ class Database(IDatabase):
         Databases built for the old GUI shipped the topobathy/index data as
         PNG tiles under ``static/dem/tiles``. The current GUI
         (Guitares image overlays via cht_tiling) instead reads single GeoTIFFs:
-        the subgrid DEM (``{self.site.sfincs.dem.filename}.tif``) and an index raster (``index.tif``).
-
+        the subgrid DEM (``{self.site.sfincs.dem.filename}``) and an index raster (``index.tif``).
         This runs once when a database is opened and:
           1. Generates ``index.tif`` from the overland SFINCS model if it is missing.
           2. Deletes the deprecated ``static/dem/tiles`` folder if it is present.

--- a/flood_adapt/dbs_classes/database.py
+++ b/flood_adapt/dbs_classes/database.py
@@ -341,7 +341,7 @@ class Database(IDatabase):
             logger.warning(
                 f"Removing deprecated DEM tile pyramids at {tiles_dir.as_posix()}. The "
                 "GUI no longer renders raster layers from PNG tiles; it uses the single "
-                f"GeoTIFFs ({self.site.sfincs.dem.filename}.tif / index.tif) instead, so these tiles are no "
+                f"GeoTIFFs ({self.site.sfincs.dem.filename} / index.tif) instead, so these tiles are no "
                 "longer used and are being deleted to avoid confusion and save space."
             )
             try:

--- a/flood_adapt/dbs_classes/database.py
+++ b/flood_adapt/dbs_classes/database.py
@@ -280,23 +280,23 @@ class Database(IDatabase):
         return self.scenarios.output_path.joinpath(scenario_name, "Flooding")
 
     def get_topobathy_path(self) -> str:
-        """Return the path of the topobathy tiles in order to create flood maps with water level maps.
+        """Return the path of the topobathy GeoTIFF in order to create flood maps with water level maps.
 
         Returns
         -------
         str
-            path to topobathy tiles
+            path to topobathy GeoTIFF
         """
         path = self.static_path / "dem" / self.site.sfincs.dem.filename
         return path.as_posix()
 
     def get_index_path(self) -> str:
-        """Return the path of the index tiles which are used to connect each water level cell with the topobathy tiles.
+        """Return the path of the index GeoTIFF which is used to connect each water level cell with the topobathy GeoTIFF.
 
         Returns
         -------
         str
-            path to index tiles
+            path to index GeoTIFF
         """
         index_path = self.static_path / "dem" / "index.tif"
         return index_path.as_posix()

--- a/flood_adapt/dbs_classes/database.py
+++ b/flood_adapt/dbs_classes/database.py
@@ -117,6 +117,10 @@ class Database(IDatabase):
 
         self._init_done = True
 
+        # Bring the database dem and index data up to date with what the GUI expects
+        # (single GeoTIFFs instead of the deprecated tiles).
+        self._migrate_deprecated_tiles()
+
         # Delete any unfinished/crashed scenario output after initialization
         self.cleanup()
 
@@ -283,7 +287,7 @@ class Database(IDatabase):
         str
             path to topobathy tiles
         """
-        path = self.input_path.parent.joinpath("static", "dem", "tiles", "topobathy")
+        path = self.static_path / "dem" / self.site.sfincs.dem.filename
         return path.as_posix()
 
     def get_index_path(self) -> str:
@@ -294,8 +298,83 @@ class Database(IDatabase):
         str
             path to index tiles
         """
-        path = self.input_path.parent.joinpath("static", "dem", "tiles", "indices")
-        return path.as_posix()
+        index_path = self.static_path / "dem" / "index.tif"
+        return index_path.as_posix()
+
+    def _migrate_deprecated_tiles(self) -> None:
+        """Update the static DEM data to the single-GeoTIFF format the GUI expects.
+
+        Databases built for the old GUI shipped the topobathy/index data as
+        PNG tiles under ``static/dem/tiles``. The current GUI
+        (Guitares image overlays via cht_tiling) instead reads single GeoTIFFs:
+        the subgrid DEM (``{self.site.sfincs.dem.filename}.tif``) and an index raster (``index.tif``).
+
+        This runs once when a database is opened and:
+          1. Generates ``index.tif`` from the overland SFINCS model if it is missing.
+          2. Deletes the deprecated ``static/dem/tiles`` folder if it is present.
+
+        All actions are logged with a warning explaining why, since this mutates the
+        opened database on disk. Failures are caught and logged so that opening the
+        database never fails because of this migration; if the index cannot be
+        generated the flood map simply will not render until it is available.
+        """
+        dem_dir = self.static_path / "dem"
+        index_path = dem_dir / "index.tif"
+        tiles_dir = dem_dir / "tiles"
+
+        # 1. Ensure the index GeoTIFF exists.
+        if not index_path.exists():
+            logger.warning(
+                f"Index GeoTIFF not found at {index_path.as_posix()}. This database "
+                "predates the single-GeoTIFF DEM format used by the GUI. Generating it "
+                "once from the overland SFINCS model; this may take a moment."
+            )
+            try:
+                self._generate_index_geotiff(index_path)
+            except Exception as e:
+                logger.warning(
+                    f"Could not generate the index GeoTIFF at {index_path.as_posix()}: "
+                    f"{e}. The flood map will not render until it is available."
+                )
+
+        # 2. Remove the deprecated tile pyramids.
+        if tiles_dir.exists():
+            logger.warning(
+                f"Removing deprecated DEM tile pyramids at {tiles_dir.as_posix()}. The "
+                "GUI no longer renders raster layers from PNG tiles; it uses the single "
+                f"GeoTIFFs ({self.site.sfincs.dem.filename}.tif / index.tif) instead, so these tiles are no "
+                "longer used and are being deleted to avoid confusion and save space."
+            )
+            try:
+                shutil.rmtree(tiles_dir)
+            except Exception as e:
+                logger.warning(
+                    f"Could not delete the deprecated tiles folder {tiles_dir.as_posix()}: "
+                    f"{e}. It is unused and can be removed manually."
+                )
+
+    def _generate_index_geotiff(self, index_path: Path) -> None:
+        """Generate the index GeoTIFF from the overland SFINCS model and the subgrid DEM.
+
+        Mirrors flood_adapt's ``database_builder.create_dem_model``: each high-resolution
+        DEM pixel is mapped to its SFINCS grid cell index. Heavy imports are done lazily.
+        """
+        from hydromt_sfincs import SfincsModel as HydromtSfincsModel
+        from hydromt_sfincs.workflows.downscaling import make_index_cog
+
+        overland_root = self.static_path / "templates" / "overland"
+        logger.info(
+            f"Generating index GeoTIFF at {index_path.as_posix()} from SFINCS model "
+            f"{overland_root.as_posix()} ..."
+        )
+        index_path.parent.mkdir(parents=True, exist_ok=True)
+        model = HydromtSfincsModel(root=overland_root.resolve().as_posix(), mode="r")
+        model.read()
+        make_index_cog(
+            model=model,
+            indices_fn=index_path,
+            topobathy_fn=self.get_topobathy_path(),
+        )
 
     def get_depth_conversion(self) -> float:
         """Return the flood depth conversion that is need in the gui to plot the flood map.
@@ -349,6 +428,11 @@ class Database(IDatabase):
             )
             with xr.open_dataset(file_path) as ds:
                 zsmax = ds["risk_map"][:, :].to_numpy().T
+        # Flatten to a 1D per-cell array in Fortran order, matching the cell
+        # numbering of the index GeoTIFF (make_index_cog), as expected by the
+        # cht_tiling FloodMap used by the GUI.
+        if zsmax.ndim >= 2:
+            zsmax = zsmax.flatten("F")
         return zsmax
 
     def get_flood_map_geotiff(

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -394,8 +392,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -2020,7 +2016,56 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: flood-adapt
-  version: 1.1.10
+  version: 1.1.11
+  sha256: d7a8601f1637773fca704ba643e5655c07ddec5bc1079aca1de9ba3945f7c4d3
+  requires_dist:
+  - cht-cyclones==1.0.3
+  - cht-meteo==0.3.1
+  - cht-observations==0.2.1
+  - cht-tide==0.1.1
+  - fiat-toolbox==0.1.23
+  - fiona>=1.0,<2.0
+  - geojson>=3.0,<4.0
+  - geopandas>=1.0,<2.0
+  - hydromt-fiat>=0.5.9,<1.0
+  - hydromt-sfincs>=1.2.2,<2.0
+  - numpy>=1.0,<2.0
+  - numpy-financial>=1.0,<2.0
+  - pandas>=2.0,<3.0
+  - plotly>=6.0,<6.3
+  - pydantic>=2.0,<3.0
+  - pydantic-settings>=2.0,<3.0
+  - pyogrio<1.0
+  - tomli>=2.0,<3.0
+  - tomli-w>=1.0,<2.0
+  - typing-extensions
+  - pytest>=8.0,<9.0 ; extra == 'dev'
+  - pytest-cov>=6.0,<7.0 ; extra == 'dev'
+  - pre-commit==3.8.0 ; extra == 'dev'
+  - ruff==0.5.5 ; extra == 'dev'
+  - typos==1.23.6 ; extra == 'dev'
+  - build>=1.2,<2.0 ; extra == 'build'
+  - twine>=6.0,<7.0 ; extra == 'build'
+  - pyinstaller==6.13.0 ; extra == 'build'
+  - pefile<2024.8.26 ; extra == 'build'
+  - jupyter>=1.0,<2.0 ; extra == 'docs'
+  - jupyter-cache>=1.0,<2.0 ; extra == 'docs'
+  - nbstripout>=0.8.0,<0.9 ; extra == 'docs'
+  - matplotlib>=3.0,<4.0 ; extra == 'docs'
+  - quartodoc>=0.9.0,<1.0 ; extra == 'docs'
+  - sphinx>=8.0,<9.0 ; extra == 'docs'
+  - sphinx-rtd-theme>=3.0,<4.0 ; extra == 'docs'
+  - regex>=2024.11,<2025.0 ; extra == 'docs'
+  - minio>=7.2.15,<8 ; extra == 'docs'
+  - python-dotenv>=1.0,<2.0 ; extra == 'docs'
+  - folium>=0.19.0,<1.0 ; extra == 'docs'
+  - mapclassify>=2.8.0,<3.0 ; extra == 'docs'
+  - contextily ; extra == 'docs'
+  requires_python: '>=3.10,<3.13'
+  editable: true
+- pypi: ./
+  name: flood-adapt
+  version: 1.1.11
   sha256: d7a8601f1637773fca704ba643e5655c07ddec5bc1079aca1de9ba3945f7c4d3
   requires_dist:
   - cht-cyclones==1.0.3

--- a/tests/test_database_builder/test_database_builder.py
+++ b/tests/test_database_builder/test_database_builder.py
@@ -1,5 +1,4 @@
 import logging
-import shutil
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -645,72 +644,22 @@ class TestDataBaseBuilder:
         )
         builder = DatabaseBuilder(mock_config)
         builder.setup()
-        root = Path(builder.sfincs_overland_model.root)
-        assert not (root / "tiles/indices").exists()
-        assert not (root / "tiles/topobathy").exists()
 
         # Act
         dem = builder.create_dem_model()
 
         # Assert
         expected_tif = builder.static_path / "dem" / Path(mock_config.dem.filename).name
+        expected_indices = builder.static_path / "dem" / "index.tif"
         expected_dem = DemModel(
             filename=expected_tif.name,
             units=mock_config.dem.units,
+            index_file=expected_indices.name,
         )
-        expected_tiles = builder.static_path / "dem" / "tiles"
-        expected_indices = expected_tiles / "indices"
-        expected_topo = expected_tiles / "topobathy"
 
         assert dem == expected_dem
 
-        for file in [
-            expected_tif,
-            expected_tiles,
-            expected_indices,
-            expected_topo,
-        ]:
-            assert file.exists()
-
-    def test_create_dem_model_tiles_moved(self, mock_config: ConfigModel):
-        # Arrange
-        mock_config.dem = DemModel(
-            filename=str(self.static_path / "dem/charleston_14m.tif"),
-            units=us.UnitTypesLength.meters,
-        )
-        tiles_path = self.static_path / "dem/tiles"
-        indices_path = tiles_path / "indices"
-        topo_path = tiles_path / "topobathy"
-        for file in [tiles_path, indices_path, topo_path]:
-            assert file.exists()
-
-        builder = DatabaseBuilder(mock_config)
-        builder.setup()
-        builder.sfincs_overland_model.setup_tiles = Mock()
-        shutil.copytree(tiles_path, Path(builder.sfincs_overland_model.root) / "tiles")
-
-        # Act
-        dem = builder.create_dem_model()
-
-        # Assert
-        builder.sfincs_overland_model.setup_tiles.assert_not_called()
-        expected_tif = builder.static_path / "dem" / Path(mock_config.dem.filename).name
-        expected_dem = DemModel(
-            filename=expected_tif.name,
-            units=mock_config.dem.units,
-        )
-        expected_tiles = builder.static_path / "dem" / "tiles"
-        expected_indices = expected_tiles / "indices"
-        expected_topo = expected_tiles / "topobathy"
-
-        assert dem == expected_dem
-
-        for file in [
-            expected_tif,
-            expected_tiles,
-            expected_indices,
-            expected_topo,
-        ]:
+        for file in [expected_tif, expected_indices]:
             assert file.exists()
 
     def test_create_tide_gauge_file_based(

--- a/typos.toml
+++ b/typos.toml
@@ -10,3 +10,5 @@ ignore-hidden = true
 
 [default.extend-words]
 strat = "strat"
+guitares = "guitares"
+Guitares = "Guitares"


### PR DESCRIPTION
  Summary

  Backend support for the new MapLibre/Guitares GUI, which renders raster layers (topography and flood maps) as server-side image overlays via cht_tiling
  instead of client-side PNG tile pyramids. The database builder now produces a single index GeoTIFF, existing databases are migrated automatically on
  open, and the risk-infographic path now raises a clear, actionable error instead of a cryptic KeyError.

  Changes

  1. Database builder: index GeoTIFF instead of PNG tiles (database_builder.py)
  - create_dem_model no longer moves/builds static/dem/tiles PNG pyramids. It now generates a single index.tif (via hydromt_sfincs … make_index_cog) that
  maps each high-res DEM pixel to its SFINCS grid cell, alongside the subgrid DEM GeoTIFF.
  - The GUI reads DEM.tif + index.tif directly, so the deprecated tiling step (and the os/setup_tiles code path) is removed.

  2. Automatic migration of older databases (dbs_classes/database.py)
  - New _migrate_deprecated_tiles() runs once on database open and:
    a. Generates index.tif from the overland SFINCS model if it's missing (_generate_index_geotiff).
    b. Deletes the deprecated static/dem/tiles folder if present.
  - Both actions are logged as warnings (this mutates the database on disk), and all failures are caught and logged so opening a database never fails
  because of the migration — at worst the flood map doesn't render until the index is available.
  - get_topobathy_path() / get_index_path() now point at the single GeoTIFFs (static/dem/<dem>.tif, static/dem/index.tif) instead of the tile folders.
  - zsmax is now flattened in Fortran order to match the index GeoTIFF's cell numbering expected by cht_tiling's FloodMap.

  3. Clearer risk-infographic errors (adapter/fiat_adapter.py)
  - Wrapped infographic creation so a missing query field in config_risk_charts.toml (introduced by newer fiat_toolbox, which switched from hardcoded
  metric names to config-driven ones) raises an explanatory error showing exactly which lines to add, rather than a bare KeyError: 'query'.
  - A query pointing at a non-existent metric now reports which metric is missing and where to look.
