### PR TITLE
fix(benefits): benefit analysis crash - metadata row leaking into numeric data

### DIFF
--- a/flood_adapt/workflows/benefit_runner.py
+++ b/flood_adapt/workflows/benefit_runner.py
@@ -20,6 +20,16 @@ from flood_adapt.misc.path_builder import (
 from flood_adapt.objects.benefits.benefits import Benefit
 from flood_adapt.objects.scenarios.scenarios import Scenario
 
+# Metadata rows that may precede the aggregation-zone values in the infometrics
+# file. Their count/order is not stable (e.g. "Show In Metrics Map" was added
+# later), so they are dropped by name, not by position.
+INFOMETRICS_METADATA_ROWS = [
+    "Description",
+    "Long Name",
+    "Show In Metrics Table",
+    "Show In Metrics Map",
+]
+
 
 class BenefitRunner:
     """Object holding all attributes and methods related to a benefit analysis."""
@@ -353,7 +363,10 @@ class BenefitRunner:
                     # Get metrics per scenario and per aggregation
                     aggregated_metrics = MetricsFileReader(
                         aggregation_fn,
-                    ).read_aggregated_metric_from_file(var_metric[var])[2:]
+                    ).read_aggregated_metric_from_file(var_metric[var])
+                    aggregated_metrics = aggregated_metrics.drop(
+                        index=INFOMETRICS_METADATA_ROWS, errors="ignore"
+                    )
                     aggregated_metrics = aggregated_metrics.loc[
                         aggregated_metrics.index.dropna()
                     ]


### PR DESCRIPTION
  Problem

  Running a benefit (cost-benefit) analysis crashed with:
  ValueError: could not convert string to float: 'Expected Annual Damages'
  in benefit_runner.cba_aggregation().

  Cause

  Aggregated infometrics CSVs carry 4 metadata rows (Description, Show In Metrics Map, Show In Metrics
  Table, Long Name) before the zone data, but the read path only stripped 3 of them —
  read_aggregated_metric_from_file() drops Description, then the benefit runner sliced off [2:]. That
  left the Long Name row (value "Expected Annual Damages") in the series, so the subsequent
  astype(float) failed. The extra Show In Metrics Map row is what broke the old positional assumption.

  Fix

  Drop the known metadata rows by name instead of by position, so the code is independent of how
  many/which metadata rows precede the data:
  - Added an INFOMETRICS_METADATA_ROWS constant.
  - Replaced the brittle [2:] slice with .drop(index=INFOMETRICS_METADATA_ROWS, errors="ignore").
